### PR TITLE
Support Clang header modules in the rules-based toolchain

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -2,6 +2,10 @@
 # It is referenced with a --bazelrc option in the call to bazel in ci.yaml
 common --config=ci
 
+# The default heap size (1/4 of the runner's 16 GB) is not enough for the
+# larger e2e workspaces with Bazel 8.
+startup --host_jvm_args=-Xmx6g
+
 # Enable remote execution on CI by default.
 common --config remote
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,12 @@ jobs:
           - "e2e/rules_rs"
           - "e2e/cross_compilation"
           - "examples/custom_targets"
+          - "examples/header_modules"
+        exclude:
+          # Header modules require the Starlark implementation of the C++
+          # rules (Bazel 9+).
+          - bazel_version: 8.x
+            folder: "examples/header_modules"
         include:
           # Path mapping requires Bazel 9+.
           - bazel_version: last_rc

--- a/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
@@ -135,6 +135,55 @@ copy_to_directory(
     visibility = ["//visibility:public"],
 )
 
+# The libc++ headers, split into the public (includable) headers and the
+# implementation details so that the public headers can be compiled into a
+# Clang module (see @llvm//toolchain/features/header_modules/libcxx). The
+# public headers are the extensionless top-level headers such as <vector>.
+filegroup(
+    name = "libcxx_public_headers_files",
+    srcs = [
+        f
+        for f in (LIBCXX_HEADERS_FILES_22 if int(LLVM_VERSION_MAJOR) >= 22 else LIBCXX_HEADERS_FILES_21)
+        if "/" not in f.removeprefix("include/") and
+           "." not in f.removeprefix("include/") and
+           not f.removeprefix("include/").startswith("__")
+    ],
+)
+
+filegroup(
+    name = "libcxx_detail_headers_files",
+    srcs = [
+        ":__assertion_handler",
+        ":__config_site",
+    ] + [
+        f
+        for f in (LIBCXX_HEADERS_FILES_22 if int(LLVM_VERSION_MAJOR) >= 22 else LIBCXX_HEADERS_FILES_21)
+        if not ("/" not in f.removeprefix("include/") and
+                "." not in f.removeprefix("include/") and
+                not f.removeprefix("include/").startswith("__"))
+    ],
+)
+
+copy_to_directory(
+    name = "libcxx_public_headers_directory",
+    srcs = [":libcxx_public_headers_files"],
+    out = "libcxx_public_headers",
+    root_paths = [
+        "libcxx/include",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+copy_to_directory(
+    name = "libcxx_detail_headers_directory",
+    srcs = [":libcxx_detail_headers_files"],
+    out = "libcxx_detail_headers",
+    root_paths = [
+        "libcxx/include",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "headers",
     hdrs = [

--- a/3rd_party/macos_sdk/CLTools_macOSNMOS_SDK.BUILD.bazel
+++ b/3rd_party/macos_sdk/CLTools_macOSNMOS_SDK.BUILD.bazel
@@ -7,6 +7,43 @@ headers_directory(
     visibility = ["//visibility:public"],
 )
 
+# The public (includable) C++ standard library headers: the extensionless
+# top-level libc++ headers such as <vector>. These are compiled into a Clang
+# module by @llvm//toolchain/features/header_modules/libcxx.
+filegroup(
+    name = "libcxx_public_headers",
+    srcs = glob(
+        ["usr/include/c++/v1/*"],
+        allow_empty = True,
+        exclude = [
+            "usr/include/c++/v1/*.h",
+            "usr/include/c++/v1/*.imp",
+            "usr/include/c++/v1/*.modulemap",
+            "usr/include/c++/v1/*.txt",
+            "usr/include/c++/v1/__*",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+# All other C++ standard library headers: implementation details, which
+# include mutually exclusive variants that can't all be compiled into a
+# module, and the C standard library wrappers, which include the C standard
+# library headers via include_next and thus have to be textual.
+filegroup(
+    name = "libcxx_textual_headers",
+    srcs = glob(
+        [
+            "usr/include/c++/v1/*.h",
+            "usr/include/c++/v1/__*",
+            "usr/include/c++/v1/*/**",
+        ],
+        allow_empty = True,
+        exclude = ["usr/include/c++/v1/*.modulemap"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # The C and C++ standard library headers as an enumerated list rather than a
 # directory. Used to declare them as `textual header`s in the toolchain's
 # module map: since explicit entries win over the sysroot umbrella submodule,

--- a/3rd_party/macos_sdk/CLTools_macOSNMOS_SDK.BUILD.bazel
+++ b/3rd_party/macos_sdk/CLTools_macOSNMOS_SDK.BUILD.bazel
@@ -1,7 +1,25 @@
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
 load("@llvm//:directory.bzl", "headers_directory")
 
 headers_directory(
     name = "sysroot",
     path = ".",
+    visibility = ["//visibility:public"],
+)
+
+# The C and C++ standard library headers as an enumerated list rather than a
+# directory. Used to declare them as `textual header`s in the toolchain's
+# module map: since explicit entries win over the sysroot umbrella submodule,
+# these headers stay textual even in `-fmodules` builds, where umbrella-owned
+# headers could only be included via a compiled module. With
+# --@llvm//toolchain:libcxx_modules, the modular declarations in libc++'s own
+# module map take precedence over the textual ones (see
+# @llvm//toolchain/features/header_modules).
+directory(
+    name = "c_headers",
+    srcs = glob(
+        ["usr/include/**"],
+        allow_empty = True,
+    ),
     visibility = ["//visibility:public"],
 )

--- a/3rd_party/rules_cc/0001-add-imported-module-files-to-module-codegen-inputs.patch
+++ b/3rd_party/rules_cc/0001-add-imported-module-files-to-module-codegen-inputs.patch
@@ -1,0 +1,16 @@
+--- a/cc/private/compile/compile.bzl	2026-07-16 21:54:27
++++ b/cc/private/compile/compile.bzl	2026-07-16 21:54:27
+@@ -2063,6 +2063,13 @@
+     if fdo_context_has_artifacts:
+         additional_inputs = auxiliary_fdo_inputs.to_list()
+ 
++    # Compiling the module file to an object file causes Clang to load it,
++    # which in turn loads the module files it imports.
++    if use_pic:
++        additional_inputs = additional_inputs + cc_compilation_context._transitive_pic_modules.to_list()
++    else:
++        additional_inputs = additional_inputs + cc_compilation_context._transitive_modules.to_list()
++
+     _create_compile_action(
+         action_construction_context = action_construction_context,
+         cc_compilation_context = cc_compilation_context,

--- a/3rd_party/rules_cc/0002-expand-tree-artifacts-in-public-textual-headers.patch
+++ b/3rd_party/rules_cc/0002-expand-tree-artifacts-in-public-textual-headers.patch
@@ -1,0 +1,19 @@
+--- a/cc/private/compile/cc_compilation_helper.bzl	2026-07-17 15:40:56
++++ b/cc/private/compile/cc_compilation_helper.bzl	2026-07-17 15:40:56
+@@ -310,7 +310,7 @@
+         add_header(path = header.path, visibility = "", can_compile = False)
+         added_paths.add(header.path)
+ 
+-    for header in parameters.public_textual_headers:
++    for header in expanded(parameters.public_textual_headers):
+         if header.path in added_paths:
+             continue
+         add_header(path = header.path, visibility = "", can_compile = False)
+@@ -400,6 +400,7 @@
+     tree_artifacts = [h for h in private_headers if h.is_directory]
+     tree_artifacts += [h for h in public_headers if h.is_directory]
+     tree_artifacts += [h for h in textual_headers if h.is_directory]
++    tree_artifacts += [h for h in public_textual_headers if h.is_directory]
+     content.add_all(tree_artifacts, map_each = lambda x: None, allow_closure = True)
+ 
+     actions.write(module_map.file, content = content, is_executable = True, mnemonic = "CppModuleMap")

--- a/3rd_party/rules_cc/0003-do-not-retain-module-map-name-strings.patch
+++ b/3rd_party/rules_cc/0003-do-not-retain-module-map-name-strings.patch
@@ -1,0 +1,205 @@
+diff --git a/cc/private/cc_info.bzl b/cc/private/cc_info.bzl
+index a51d0f4..f141c35 100644
+--- a/cc/private/cc_info.bzl
++++ b/cc/private/cc_info.bzl
+@@ -152,23 +152,76 @@ _ModuleMapInfo = provider(
+     "ModuleMapInfo",
+     fields = {
+         "file": "The module map file.",
+-        "name": "The name of the module.",
++        "name": "The name of the module or None if the module is named after the label of the target that generated the module map file (see get_module_map_name).",
+     },
+ )
+ 
+-def create_module_map(*, file, name):
++def create_module_map(*, file, name = None):
+     """
+     Creates a module map struct.
+ 
+     Args:
+         file: The module map file.
+-        name: The name of the module.
++        name: The name of the module. If None (the default), the module is
++          named after the label of the target that generated the module map
++          file. Prefer the default: it avoids retaining a name string per
++          module map as the name is derived on demand from `file.owner`.
+     Returns:
+         A module map struct.
+     """
+     check_private_api()
+     return _ModuleMapInfo(file = file, name = name)
+ 
++def get_module_map_name(module_map):
++    """
++    Returns the name of the module described by a module map struct.
++
++    Module maps generated for a target are named after the target's label,
++    rendered in its unambiguous canonical form, except that main-repository
++    labels do not carry the leading double-at prefix (for example "//pkg:lib"
++    for a main-repository target). Names of targets in external repositories
++    are thus valid label strings, while main-repository names match the
++    traditional module name format.
++
++    Args:
++        module_map: The module map struct.
++    Returns:
++        The name of the module as a string.
++    """
++    if module_map.name != None:
++        return module_map.name
++    label_string = str(module_map.file.owner)
++
++    # buildifier: disable=canonical-repository
++    if label_string.startswith("@@//"):
++        return label_string[2:]
++    return label_string
++
++def get_module_map_label(module_map):
++    """
++    Returns the label a module map struct is named after.
++
++    This is only valid for module maps whose name is (derived from) a label,
++    which is the case for all module maps generated for a target, including
++    separate module maps. It is not valid for module maps with special names
++    such as the crosstool module map.
++
++    Args:
++        module_map: The module map struct.
++    Returns:
++        The Label the module's name refers to.
++    """
++    if module_map.name == None:
++        return module_map.file.owner
++
++    # Module map names of main-repository targets lack the leading "@@" (see
++    # get_module_map_name), which has to be restored for parsing to ensure
++    # that the name is not resolved relative to this file's repository.
++    name = module_map.name
++
++    # buildifier: disable=canonical-repository
++    return Label(name if name.startswith("@") else "@@" + name)
++
+ def create_separate_module_map(module_map):
+     """
+     Creates a separate module map struct.
+@@ -178,7 +231,7 @@ def create_separate_module_map(module_map):
+     Returns:
+         A module map struct.
+     """
+-    return _ModuleMapInfo(file = module_map.file, name = module_map.name + ".sep")
++    return _ModuleMapInfo(file = module_map.file, name = get_module_map_name(module_map) + ".sep")
+ 
+ def create_linking_context(
+         *,
+diff --git a/cc/private/compile/cc_compilation_helper.bzl b/cc/private/compile/cc_compilation_helper.bzl
+index ebc24c7..5c1bfaf 100644
+--- a/cc/private/compile/cc_compilation_helper.bzl
++++ b/cc/private/compile/cc_compilation_helper.bzl
+@@ -21,7 +21,7 @@ load(
+     "repository_exec_path",
+ )
+ load("//cc/common:semantics.bzl", "STRIP_INCLUDE_PREFIX_APPLIES_TO_TEXTUAL_HEADERS", "USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS")
+-load("//cc/private:cc_info.bzl", "create_compilation_context", "create_module_map")
++load("//cc/private:cc_info.bzl", "create_compilation_context", "create_module_map", "get_module_map_name")
+ load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
+ 
+ _VIRTUAL_INCLUDES_DIR = "_virtual_includes"
+@@ -252,7 +252,8 @@ _ModuleMapInfo = provider(
+ def _module_map_struct_to_module_map_content(parameters, tree_expander):
+     lines = []
+     module_map = parameters.module_map
+-    lines.append("module \"%s\" {" % module_map.name)
++    module_name = get_module_map_name(module_map)
++    lines.append("module \"%s\" {" % module_name)
+     lines.append("  export *")
+ 
+     def expanded(artifacts):
+@@ -324,10 +325,10 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
+ 
+     dependency_module_maps = parameters.dependency_module_maps.to_list()
+     for dep in dependency_module_maps:
+-        lines.append("  use \"" + dep.name + "\"")
++        lines.append("  use \"" + get_module_map_name(dep) + "\"")
+ 
+     if parameters.separate_module_headers:
+-        separate_name = module_map.name + ".sep"
++        separate_name = module_name + ".sep"
+         lines.append("  use \"" + separate_name + "\"")
+         lines.append("}")
+         lines.append("module \"" + separate_name + "\" {")
+@@ -341,14 +342,14 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
+             added_paths.add(header.path)
+ 
+         for dep in dependency_module_maps:
+-            lines.append("  use \"" + dep.name + "\"")
++            lines.append("  use \"" + get_module_map_name(dep) + "\"")
+ 
+     lines.append("}")
+ 
+     if parameters.extern_dependencies:
+         for dep in dependency_module_maps:
+             lines.append(
+-                "extern module \"" + dep.name + "\" \"" +
++                "extern module \"" + get_module_map_name(dep) + "\" \"" +
+                 parameters.leading_periods + dep.file.path + "\"",
+             )
+ 
+@@ -561,7 +562,6 @@ def _init_cc_compilation_context(
+         if not module_map:
+             module_map = create_module_map(
+                 file = actions.declare_file(label.name + ".cppmap"),
+-                name = label.workspace_name + "//" + label.package + ":" + label.name,
+             )
+ 
+         # There are different modes for module compilation:
+diff --git a/cc/private/compile/compile.bzl b/cc/private/compile/compile.bzl
+index 3aebb85..faac9aa 100644
+--- a/cc/private/compile/compile.bzl
++++ b/cc/private/compile/compile.bzl
+@@ -36,6 +36,7 @@ load(
+     "create_cc_compilation_context_with_cpp20_modules",
+     "create_compilation_context_with_extra_header_tokens",
+     "create_separate_module_map",
++    "get_module_map_label",
+ )
+ load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
+ load("//cc/private/compile:cc_compilation_helper.bzl", "cc_compilation_helper", "dotd_files_enabled", "serialized_diagnostics_file_enabled")
+@@ -1153,7 +1154,7 @@ def _create_cc_compile_actions(
+ 
+     if _should_provide_header_modules(feature_configuration, private_headers, public_headers):
+         cpp_module_map = cc_compilation_context._module_map
+-        module_map_label = Label(cpp_module_map.name)
++        module_map_label = get_module_map_label(cpp_module_map)
+         modules = _create_module_action(
+             action_construction_context = action_construction_context,
+             cc_compilation_context = cc_compilation_context,
+@@ -2109,7 +2110,7 @@ def _create_module_action(
+         additional_include_scanning_roots,
+         outputs,
+         progress_message_prefix):
+-    module_map_label = Label(cpp_module_map.name)
++    module_map_label = get_module_map_label(cpp_module_map)
+     return _create_pic_nopic_compile_source_actions(
+         action_construction_context = action_construction_context,
+         cc_compilation_context = cc_compilation_context,
+diff --git a/cc/private/compile/compile_build_variables.bzl b/cc/private/compile/compile_build_variables.bzl
+index ed76c6e..caa1a26 100644
+--- a/cc/private/compile/compile_build_variables.bzl
++++ b/cc/private/compile/compile_build_variables.bzl
+@@ -16,6 +16,7 @@ All build variables we create for various `CppCompileAction`s
+ """
+ 
+ load("//cc/common:cc_helper_internal.bzl", "extensions", "get_fdo_build_stamp", "get_linkstamp_stamps", _PRIVATE_STARLARKIFICATION_ALLOWLIST = "PRIVATE_STARLARKIFICATION_ALLOWLIST")
++load("//cc/private:cc_info.bzl", "get_module_map_name")
+ load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
+ load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
+ 
+@@ -319,7 +320,7 @@ def get_specific_compile_build_variables(
+     result = {}
+ 
+     if feature_configuration.is_enabled("module_maps") and cpp_module_map:
+-        result[_VARS.MODULE_NAME] = cpp_module_map.name
++        result[_VARS.MODULE_NAME] = get_module_map_name(cpp_module_map)
+         result[_VARS.MODULE_MAP_FILE] = cpp_module_map.file
+         result[_VARS.DEPENDENT_MODULE_MAP_FILES] = direct_module_maps
+ 

--- a/3rd_party/rules_cc/BUILD.bazel
+++ b/3rd_party/rules_cc/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["*"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,10 @@ single_version_override(
         # The module codegen action loads the module files imported by the
         # module it compiles, but doesn't have them as inputs.
         "//3rd_party/rules_cc:0001-add-imported-module-files-to-module-codegen-inputs.patch",
+        # Tree artifacts in textual_hdrs end up in generated module maps as a
+        # single header entry with the directory's path instead of one textual
+        # header entry per contained file.
+        "//3rd_party/rules_cc:0002-expand-tree-artifacts-in-public-textual-headers.patch",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,16 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "bazel_features", version = "1.42.0")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.20")
+single_version_override(
+    module_name = "rules_cc",
+    patch_strip = 1,
+    patches = [
+        # The module codegen action loads the module files imported by the
+        # module it compiles, but doesn't have them as inputs.
+        "//3rd_party/rules_cc:0001-add-imported-module-files-to-module-codegen-inputs.patch",
+    ],
+)
+
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "with_cfg.bzl", version = "0.12.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,10 @@ single_version_override(
         # single header entry with the directory's path instead of one textual
         # header entry per contained file.
         "//3rd_party/rules_cc:0002-expand-tree-artifacts-in-public-textual-headers.patch",
+        # The module map name of targets in external repositories is not a
+        # valid label and fails to parse when creating the module compile
+        # action.
+        "//3rd_party/rules_cc:0003-do-not-retain-module-map-name-strings.patch",
     ],
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 24,
+  "lockFileVersion": 26,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -9,9 +9,14 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
-    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
-    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
@@ -27,14 +32,17 @@
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.24.0/MODULE.bazel": "4796b4c25b47053e9bbffa792b3792d07e228ff66cd0405faef56a978708acd4",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
+    "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
     "https://bcr.bazel.build/modules/bazel_features/1.50.0/MODULE.bazel": "2083ef9c7a469f520890483ccf8e0189d6e71e2117e7752e15e6554433d5ae3e",
     "https://bcr.bazel.build/modules/bazel_features/1.50.0/source.json": "e0ee3debde2789ff56e4452e612d126925ba9ab64d4bde79c67f099d2902df9b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
@@ -63,8 +71,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib_gazelle_plugin/1.9.0/source.json": "02385c6bf129986a5675bd04658b2c2bb6249db51106bb20db7723a56eb03302",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1.2/MODULE.bazel": "9a6e0a2e87d1e3da679e157da5192ea351d5739ca1ff51831c2b736d5b6034de",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1.2/source.json": "33e11b3bf11e39cb762480a7e6ea1d24d044636135cdd8b8e74b07ebcd3b8d8b",
-    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
-    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
+    "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/MODULE.bazel": "29ecf4babfd3c762be00d7573c288c083672ab60e79c833ff7f49ee662e54471",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/source.json": "8be4a3ef2599693f759e5c0990a4cc5a246ac08db4c900a38f852ba25b5c39be",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "cdf8cbe5ee750db04b78878c9633cc76e80dcf4416cbe982ac3a9222f80713c8",
@@ -81,12 +89,15 @@
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
-    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libarchive/3.8.1.bcr.2/MODULE.bazel": "895ab407599fe9a744a4aaa63072b238946aedcd84ff46facd7a4dd54d71f8fe",
     "https://bcr.bazel.build/modules/libarchive/3.8.1.bcr.2/source.json": "56f2751759b4c3a369639d21917e4a95768629e09659ba358983e92dde6d3469",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -120,20 +131,28 @@
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
-    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
+    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
+    "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
-    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
@@ -142,10 +161,14 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.11/MODULE.bazel": "e94f24f065bf2191dba2dace951814378b66a94bb3bcc48077492fe0508059b5",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.20/MODULE.bazel": "f5c07bce5ddcb99be21a0812ff5aadb439e688b7449c6542152363b2fd859c1a",
     "https://bcr.bazel.build/modules/rules_cc/0.2.20/source.json": "1155433dc6b8161bc339ce94095b337ed95feb1f048b014e10b62339d4b4239c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
@@ -153,7 +176,6 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
-    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
@@ -173,18 +195,20 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
-    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.0/MODULE.bazel": "9c064c434606d75a086f15ade5edb514308cccd1544c2b2a89bbac4310e41c71",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
@@ -199,17 +223,22 @@
     "https://bcr.bazel.build/modules/rules_platform/0.1.0/source.json": "98becf9569572719b65f639133510633eb3527fb37d347d7ef08447f3ebcf1c9",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
-    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
-    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
@@ -256,11 +285,11 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
+        ],
         "generatedRepoSpecs": {
           "com_github_jetbrains_kotlin_git": {
             "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
@@ -308,23 +337,31 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_kotlin+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
       }
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "1eE/aNv0So57EZMzcxgDSCFkzlydiaC4TpHowQfrcBk=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
+          "REPO_MAPPING:rules_python+,pypi__click rules_python++config+pypi__click",
+          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++config+pypi__colorama",
+          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++config+pypi__importlib_metadata",
+          "REPO_MAPPING:rules_python+,pypi__installer rules_python++config+pypi__installer",
+          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++config+pypi__more_itertools",
+          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++config+pypi__packaging",
+          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++config+pypi__pep517",
+          "REPO_MAPPING:rules_python+,pypi__pip rules_python++config+pypi__pip",
+          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++config+pypi__pip_tools",
+          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++config+pypi__pyproject_hooks",
+          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++config+pypi__setuptools",
+          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++config+pypi__tomli",
+          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++config+pypi__wheel",
+          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++config+pypi__zipp"
+        ],
         "generatedRepoSpecs": {
           "rules_python_internal": {
             "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
@@ -468,98 +505,17 @@
               "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_python+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python+",
-            "pypi__build",
-            "rules_python++config+pypi__build"
-          ],
-          [
-            "rules_python+",
-            "pypi__click",
-            "rules_python++config+pypi__click"
-          ],
-          [
-            "rules_python+",
-            "pypi__colorama",
-            "rules_python++config+pypi__colorama"
-          ],
-          [
-            "rules_python+",
-            "pypi__importlib_metadata",
-            "rules_python++config+pypi__importlib_metadata"
-          ],
-          [
-            "rules_python+",
-            "pypi__installer",
-            "rules_python++config+pypi__installer"
-          ],
-          [
-            "rules_python+",
-            "pypi__more_itertools",
-            "rules_python++config+pypi__more_itertools"
-          ],
-          [
-            "rules_python+",
-            "pypi__packaging",
-            "rules_python++config+pypi__packaging"
-          ],
-          [
-            "rules_python+",
-            "pypi__pep517",
-            "rules_python++config+pypi__pep517"
-          ],
-          [
-            "rules_python+",
-            "pypi__pip",
-            "rules_python++config+pypi__pip"
-          ],
-          [
-            "rules_python+",
-            "pypi__pip_tools",
-            "rules_python++config+pypi__pip_tools"
-          ],
-          [
-            "rules_python+",
-            "pypi__pyproject_hooks",
-            "rules_python++config+pypi__pyproject_hooks"
-          ],
-          [
-            "rules_python+",
-            "pypi__setuptools",
-            "rules_python++config+pypi__setuptools"
-          ],
-          [
-            "rules_python+",
-            "pypi__tomli",
-            "rules_python++config+pypi__tomli"
-          ],
-          [
-            "rules_python+",
-            "pypi__wheel",
-            "rules_python++config+pypi__wheel"
-          ],
-          [
-            "rules_python+",
-            "pypi__zipp",
-            "rules_python++config+pypi__zipp"
-          ]
-        ]
+        }
       }
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
         "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
         "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,platforms platforms"
+        ],
         "generatedRepoSpecs": {
           "uv": {
             "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
@@ -579,33 +535,21 @@
               "toolchain_target_settings": {}
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_python+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python+",
-            "platforms",
-            "platforms"
-          ]
-        ]
+        }
       }
     },
     "@@rules_zig+//zig:extensions.bzl%zig": {
       "general": {
         "bzlTransitiveDigest": "9uys8L7jXYI/4M4r6lbITbi6m7lwSuthCl8UPL0qPbw=",
         "usagesDigest": "DUmQlyP0R7Wb6WM3EbOrSG+d1Qq6o3nAoqiLeHANY6c=",
-        "recordedFileInputs": {
-          "@@//zig_index.json": "65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
-          "@@glibc-stubs-generator+//zig_index.json": "65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
-          "@@libstdcxx-stubs-generator+//zig_index.json": "65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
-          "@@rules_zig+//zig/private/versions.json": "3afa7e1c4af939bdb64eff3f65908bb57f2b0e46b5636e6ed15ad79256c9436f"
-        },
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_zig+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:rules_zig+,bazel_tools bazel_tools",
+          "FILE:@@//zig_index.json 65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
+          "FILE:@@glibc-stubs-generator+//zig_index.json 65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
+          "FILE:@@libstdcxx-stubs-generator+//zig_index.json 65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
+          "FILE:@@rules_zig+//zig/private/versions.json 3afa7e1c4af939bdb64eff3f65908bb57f2b0e46b5636e6ed15ad79256c9436f"
+        ],
         "generatedRepoSpecs": {
           "zig_0.14.0_aarch64-linux": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
@@ -742,19 +686,7 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_zig+",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
-          [
-            "rules_zig+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
       }
     }
   },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 26,
+  "lockFileVersion": 24,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -9,14 +9,9 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
-    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
-    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
-    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
@@ -32,17 +27,14 @@
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.24.0/MODULE.bazel": "4796b4c25b47053e9bbffa792b3792d07e228ff66cd0405faef56a978708acd4",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
-    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
-    "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
     "https://bcr.bazel.build/modules/bazel_features/1.50.0/MODULE.bazel": "2083ef9c7a469f520890483ccf8e0189d6e71e2117e7752e15e6554433d5ae3e",
     "https://bcr.bazel.build/modules/bazel_features/1.50.0/source.json": "e0ee3debde2789ff56e4452e612d126925ba9ab64d4bde79c67f099d2902df9b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
@@ -71,8 +63,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib_gazelle_plugin/1.9.0/source.json": "02385c6bf129986a5675bd04658b2c2bb6249db51106bb20db7723a56eb03302",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1.2/MODULE.bazel": "9a6e0a2e87d1e3da679e157da5192ea351d5739ca1ff51831c2b736d5b6034de",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1.2/source.json": "33e11b3bf11e39cb762480a7e6ea1d24d044636135cdd8b8e74b07ebcd3b8d8b",
-    "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
-    "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/MODULE.bazel": "29ecf4babfd3c762be00d7573c288c083672ab60e79c833ff7f49ee662e54471",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/source.json": "8be4a3ef2599693f759e5c0990a4cc5a246ac08db4c900a38f852ba25b5c39be",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "cdf8cbe5ee750db04b78878c9633cc76e80dcf4416cbe982ac3a9222f80713c8",
@@ -89,15 +81,12 @@
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
-    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libarchive/3.8.1.bcr.2/MODULE.bazel": "895ab407599fe9a744a4aaa63072b238946aedcd84ff46facd7a4dd54d71f8fe",
     "https://bcr.bazel.build/modules/libarchive/3.8.1.bcr.2/source.json": "56f2751759b4c3a369639d21917e4a95768629e09659ba358983e92dde6d3469",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -131,28 +120,20 @@
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
-    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
-    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
-    "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
-    "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
-    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
-    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
-    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
-    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
@@ -161,14 +142,10 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
-    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.11/MODULE.bazel": "e94f24f065bf2191dba2dace951814378b66a94bb3bcc48077492fe0508059b5",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.20/MODULE.bazel": "f5c07bce5ddcb99be21a0812ff5aadb439e688b7449c6542152363b2fd859c1a",
     "https://bcr.bazel.build/modules/rules_cc/0.2.20/source.json": "1155433dc6b8161bc339ce94095b337ed95feb1f048b014e10b62339d4b4239c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
@@ -176,6 +153,7 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
@@ -195,20 +173,18 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.0/MODULE.bazel": "9c064c434606d75a086f15ade5edb514308cccd1544c2b2a89bbac4310e41c71",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
-    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
@@ -223,22 +199,17 @@
     "https://bcr.bazel.build/modules/rules_platform/0.1.0/source.json": "98becf9569572719b65f639133510633eb3527fb37d347d7ef08447f3ebcf1c9",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
-    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
-    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
-    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
-    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
-    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
-    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
-    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
@@ -283,35 +254,13 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
-        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
-        "recordedInputs": [
-          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
-          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
-        ],
-        "generatedRepoSpecs": {
-          "pybind11": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
-              "strip_prefix": "pybind11-2.12.0",
-              "urls": [
-                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
-              ]
-            }
-          }
-        }
-      }
-    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
+        "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedInputs": [
-          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
-        ],
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "com_github_jetbrains_kotlin_git": {
             "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
@@ -359,31 +308,23 @@
               ]
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
+        "bzlTransitiveDigest": "1eE/aNv0So57EZMzcxgDSCFkzlydiaC4TpHowQfrcBk=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
-        "recordedInputs": [
-          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
-          "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
-          "REPO_MAPPING:rules_python+,pypi__click rules_python++config+pypi__click",
-          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++config+pypi__colorama",
-          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++config+pypi__importlib_metadata",
-          "REPO_MAPPING:rules_python+,pypi__installer rules_python++config+pypi__installer",
-          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++config+pypi__more_itertools",
-          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++config+pypi__packaging",
-          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++config+pypi__pep517",
-          "REPO_MAPPING:rules_python+,pypi__pip rules_python++config+pypi__pip",
-          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++config+pypi__pip_tools",
-          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++config+pypi__pyproject_hooks",
-          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++config+pypi__setuptools",
-          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++config+pypi__tomli",
-          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++config+pypi__wheel",
-          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++config+pypi__zipp"
-        ],
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "rules_python_internal": {
             "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
@@ -527,17 +468,98 @@
               "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_python+",
+            "pypi__build",
+            "rules_python++config+pypi__build"
+          ],
+          [
+            "rules_python+",
+            "pypi__click",
+            "rules_python++config+pypi__click"
+          ],
+          [
+            "rules_python+",
+            "pypi__colorama",
+            "rules_python++config+pypi__colorama"
+          ],
+          [
+            "rules_python+",
+            "pypi__importlib_metadata",
+            "rules_python++config+pypi__importlib_metadata"
+          ],
+          [
+            "rules_python+",
+            "pypi__installer",
+            "rules_python++config+pypi__installer"
+          ],
+          [
+            "rules_python+",
+            "pypi__more_itertools",
+            "rules_python++config+pypi__more_itertools"
+          ],
+          [
+            "rules_python+",
+            "pypi__packaging",
+            "rules_python++config+pypi__packaging"
+          ],
+          [
+            "rules_python+",
+            "pypi__pep517",
+            "rules_python++config+pypi__pep517"
+          ],
+          [
+            "rules_python+",
+            "pypi__pip",
+            "rules_python++config+pypi__pip"
+          ],
+          [
+            "rules_python+",
+            "pypi__pip_tools",
+            "rules_python++config+pypi__pip_tools"
+          ],
+          [
+            "rules_python+",
+            "pypi__pyproject_hooks",
+            "rules_python++config+pypi__pyproject_hooks"
+          ],
+          [
+            "rules_python+",
+            "pypi__setuptools",
+            "rules_python++config+pypi__setuptools"
+          ],
+          [
+            "rules_python+",
+            "pypi__tomli",
+            "rules_python++config+pypi__tomli"
+          ],
+          [
+            "rules_python+",
+            "pypi__wheel",
+            "rules_python++config+pypi__wheel"
+          ],
+          [
+            "rules_python+",
+            "pypi__zipp",
+            "rules_python++config+pypi__zipp"
+          ]
+        ]
       }
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
         "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
         "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
-        "recordedInputs": [
-          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
-          "REPO_MAPPING:rules_python+,platforms platforms"
-        ],
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "uv": {
             "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
@@ -557,21 +579,33 @@
               "toolchain_target_settings": {}
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_python+",
+            "platforms",
+            "platforms"
+          ]
+        ]
       }
     },
     "@@rules_zig+//zig:extensions.bzl%zig": {
       "general": {
         "bzlTransitiveDigest": "9uys8L7jXYI/4M4r6lbITbi6m7lwSuthCl8UPL0qPbw=",
         "usagesDigest": "DUmQlyP0R7Wb6WM3EbOrSG+d1Qq6o3nAoqiLeHANY6c=",
-        "recordedInputs": [
-          "REPO_MAPPING:rules_zig+,bazel_skylib bazel_skylib+",
-          "REPO_MAPPING:rules_zig+,bazel_tools bazel_tools",
-          "FILE:@@//zig_index.json 65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
-          "FILE:@@glibc-stubs-generator+//zig_index.json 65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
-          "FILE:@@libstdcxx-stubs-generator+//zig_index.json 65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
-          "FILE:@@rules_zig+//zig/private/versions.json 3afa7e1c4af939bdb64eff3f65908bb57f2b0e46b5636e6ed15ad79256c9436f"
-        ],
+        "recordedFileInputs": {
+          "@@//zig_index.json": "65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
+          "@@glibc-stubs-generator+//zig_index.json": "65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
+          "@@libstdcxx-stubs-generator+//zig_index.json": "65c1657b5774897d7a5d60a45df88d698edc6de18421a9f378f7c891af7970a0",
+          "@@rules_zig+//zig/private/versions.json": "3afa7e1c4af939bdb64eff3f65908bb57f2b0e46b5636e6ed15ad79256c9436f"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "zig_0.14.0_aarch64-linux": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
@@ -708,7 +742,19 @@
               ]
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_zig+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_zig+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     }
   },

--- a/examples/header_modules/.bazelrc
+++ b/examples/header_modules/.bazelrc
@@ -1,0 +1,79 @@
+common --enable_platform_specific_config
+common --experimental_fetch_all_coverage_outputs
+common --heap_dump_on_oom
+common --incompatible_default_to_explicit_init_py
+common --incompatible_enforce_starlark_utf8=error
+common --incompatible_modify_execution_info_additive
+common --incompatible_strict_action_env
+common --module_mirrors="https://bcr.cloudflaremirrors.com"
+common --nobuild_runfile_links
+common --noexperimental_check_external_repository_files
+common --nosandbox_default_allow_network
+common --repo_env="JAVA_HOME=../bazel_tools/jdk"
+common --reuse_sandbox_directories
+common --show_result=20
+common --test_output=errors
+
+common:ci --announce_rc
+common:ci --color=yes
+common:ci --show_timestamps
+test:ci --test_summary=terse
+
+# Don’t want to push a rules author to update their deps if not needed.
+# https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies
+# https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
+common --check_direct_dependencies=off
+
+common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common --repo_env=BAZEL_DO_NOT_DETECT_SWIFT_TOOLCHAIN=1
+
+common --experimental_cc_static_library
+common --experimental_platform_in_output_dir
+
+common --incompatible_config_setting_private_default_visibility
+
+common:cc --@rules_python//python/config_settings:bootstrap_impl=script
+
+common:release  -c opt
+common:release  --strip=always
+common:release  --stripopt=--strip-all
+common:release  --features=thin_lto
+common:release  --copt=-fno-exceptions
+common:release  --copt=-fno-rtti
+common:release  --copt=-fomit-frame-pointer
+common:release  --dynamic_mode=off
+common:release  --extra_toolchains=//toolchain:all
+common:release  --extra_execution_platforms=@llvm//:rbe_linux_x86_64,@llvm//:rbe_linux_aarch64
+
+common:rust    --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=False
+common:rust    --@rules_rust//rust/settings:experimental_use_sh_toolchain_for_bootstrap_process_wrapper
+
+common --bes_results_url=https://app.buildbuddy.io/invocation/
+common --bes_backend=grpcs://remote.buildbuddy.io
+common --experimental_remote_downloader=grpcs://remote.buildbuddy.io
+common --grpc_keepalive_time=30s
+common --remote_cache=grpcs://remote.buildbuddy.io
+common --remote_cache_compression
+common --remote_download_toplevel
+common --nobuild_runfile_links
+common --remote_timeout=120
+common --noexperimental_throttle_remote_action_building
+common --experimental_remote_execution_keepalive
+common --grpc_keepalive_time=30s
+common:remote --remote_executor=grpcs://remote.buildbuddy.io
+common:remote --jobs=800
+common:remote --extra_execution_platforms=@llvm//:rbe_platform
+common:remote --rewind_lost_inputs
+
+common --per_file_copt=external/.*llvm-project.*@-Wno-thread-safety-analysis
+common --host_per_file_copt=external/.*llvm-project.*@-Wno-thread-safety-analysis
+
+# Load any settings specific to the current user.
+# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
+# This needs to be last statement in this
+# config, as the user configuration should be able to overwrite flags from this file.
+# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
+# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
+# rather than user.bazelrc as suggested in the Bazel docs)
+try-import %workspace%/.bazelrc.user

--- a/examples/header_modules/BUILD.bazel
+++ b/examples/header_modules/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+# All targets in this package compile their headers into Clang header modules
+# (.pcm files), and import their dependencies' modules instead of parsing
+# their headers textually. Requires Bazel 9+ (the Starlark implementation of
+# the C++ rules).
+package(features = [
+    "header_modules",
+    "use_header_modules",
+    "layering_check",
+])
+
+# Without a dependency on the libcxx target, C++ standard library headers are
+# parsed textually (they are declared as textual headers in the toolchain's
+# module map), including into this library's own module. This works well for
+# small module graphs, but importing many modules that each textually
+# absorbed the standard library headers is known to trip up Clang's
+# declaration merging.
+cc_library(
+    name = "greeting_textual",
+    srcs = ["greeting.cc"],
+    hdrs = ["greeting.h"],
+)
+
+cc_test(
+    name = "greeting_textual_test",
+    srcs = ["main.cc"],
+    deps = [":greeting_textual"],
+)
+
+# With a dependency on the libcxx target, the public C++ standard library
+# headers are compiled once into a Clang module and imported instead: each
+# translation unit no longer re-parses them, and there is only a single set
+# of standard library declarations across all modules. The dependency also
+# declares the standard library module as used, which layering_check
+# requires.
+cc_library(
+    name = "greeting",
+    srcs = ["greeting.cc"],
+    hdrs = ["greeting.h"],
+    deps = ["@llvm//toolchain/features/header_modules/libcxx"],
+)
+
+cc_test(
+    name = "greeting_test",
+    srcs = ["main.cc"],
+    deps = [
+        ":greeting",
+        "@llvm//toolchain/features/header_modules/libcxx",
+    ],
+)

--- a/examples/header_modules/MODULE.bazel
+++ b/examples/header_modules/MODULE.bazel
@@ -1,0 +1,57 @@
+module(
+    name = "header_modules_example",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "llvm", version = "")
+local_path_override(
+    module_name = "llvm",
+    path = "../../",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")
+
+# Header modules require rules_cc fixes that are not yet part of a release.
+# single_version_override only takes effect in the root module and only
+# accepts patches from the main repository, so users of the toolchain have to
+# copy its rules_cc patches (see @llvm//3rd_party/rules_cc) and apply them
+# themselves.
+single_version_override(
+    module_name = "rules_cc",
+    patch_strip = 1,
+    patches = [
+        "//patches:0001-add-imported-module-files-to-module-codegen-inputs.patch",
+        "//patches:0002-expand-tree-artifacts-in-public-textual-headers.patch",
+        "//patches:0003-do-not-retain-module-map-name-strings.patch",
+    ],
+    version = "0.2.20",
+)
+
+toolchain = use_extension("@llvm//extensions:toolchain.bzl", "toolchain")
+toolchain.exec(
+    arch = "x86_64",
+    os = "linux",
+)
+toolchain.exec(
+    arch = "aarch64",
+    os = "linux",
+)
+toolchain.exec(
+    arch = "aarch64",
+    os = "macos",
+)
+toolchain.target(
+    arch = "x86_64",
+    os = "linux",
+)
+toolchain.target(
+    arch = "aarch64",
+    os = "linux",
+)
+toolchain.target(
+    arch = "aarch64",
+    os = "macos",
+)
+use_repo(toolchain, "llvm_toolchains")
+
+register_toolchains("@llvm_toolchains//:all")

--- a/examples/header_modules/README.md
+++ b/examples/header_modules/README.md
@@ -1,0 +1,50 @@
+# Clang header modules
+
+This example enables Clang header modules for a package: each library's
+headers are compiled once into a Clang module (a `.pcm` file), and dependents
+import the module instead of re-parsing the headers textually. Requires
+Bazel 9+ (the Starlark implementation of the C++ rules).
+
+```starlark
+package(features = [
+    "header_modules",
+    "use_header_modules",
+    "layering_check",
+])
+```
+
+## The C++ standard library
+
+System headers are declared as textual headers in the toolchain's module map,
+so they can be included without a compiled module and are simply re-parsed
+into every module that includes them (`:greeting_textual`).
+
+For anything beyond small module graphs, add a dependency on the `libcxx`
+target (`:greeting`): the public C++ standard library headers are then
+compiled once into a Clang module and imported everywhere, which is both
+faster and avoids known Clang issues with merging many textually absorbed
+copies of the standard library declarations.
+
+```starlark
+cc_library(
+    name = "greeting",
+    srcs = ["greeting.cc"],
+    hdrs = ["greeting.h"],
+    deps = ["@llvm//toolchain/features/header_modules/libcxx"],
+)
+```
+
+## Module codegen
+
+Optionally, enable `header_module_codegen` and
+`header_modules_codegen_functions` (per target or globally) to additionally
+compile each module into an object file that provides the code for inline
+functions and template instantiations triggered inside the module, which
+importing translation units then no longer emit themselves.
+
+## Caveats
+
+- Compiled modules are shared across a configuration: targets whose language
+  options diverge from the configuration-wide defaults (e.g. via per-target
+  `copts` such as `-std=` or `-fno-exceptions`) can't load them and need to
+  opt out with `features = ["-use_header_modules"]`.

--- a/examples/header_modules/greeting.cc
+++ b/examples/header_modules/greeting.cc
@@ -1,0 +1,10 @@
+#include "greeting.h"
+
+std::string Greet(const std::vector<std::string>& names) {
+  std::string greeting = "Hello";
+  for (const std::string& name : names) {
+    greeting += ", " + name;
+  }
+  greeting += "!";
+  return greeting;
+}

--- a/examples/header_modules/greeting.h
+++ b/examples/header_modules/greeting.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+std::string Greet(const std::vector<std::string>& names);

--- a/examples/header_modules/main.cc
+++ b/examples/header_modules/main.cc
@@ -1,0 +1,10 @@
+#include <cstdio>
+#include <string>
+
+#include "greeting.h"
+
+int main() {
+  std::string greeting = Greet({"header", "modules"});
+  std::printf("%s\n", greeting.c_str());
+  return greeting == "Hello, header, modules!" ? 0 : 1;
+}

--- a/examples/header_modules/patches/0001-add-imported-module-files-to-module-codegen-inputs.patch
+++ b/examples/header_modules/patches/0001-add-imported-module-files-to-module-codegen-inputs.patch
@@ -1,0 +1,16 @@
+--- a/cc/private/compile/compile.bzl	2026-07-16 21:54:27
++++ b/cc/private/compile/compile.bzl	2026-07-16 21:54:27
+@@ -2063,6 +2063,13 @@
+     if fdo_context_has_artifacts:
+         additional_inputs = auxiliary_fdo_inputs.to_list()
+ 
++    # Compiling the module file to an object file causes Clang to load it,
++    # which in turn loads the module files it imports.
++    if use_pic:
++        additional_inputs = additional_inputs + cc_compilation_context._transitive_pic_modules.to_list()
++    else:
++        additional_inputs = additional_inputs + cc_compilation_context._transitive_modules.to_list()
++
+     _create_compile_action(
+         action_construction_context = action_construction_context,
+         cc_compilation_context = cc_compilation_context,

--- a/examples/header_modules/patches/0002-expand-tree-artifacts-in-public-textual-headers.patch
+++ b/examples/header_modules/patches/0002-expand-tree-artifacts-in-public-textual-headers.patch
@@ -1,0 +1,19 @@
+--- a/cc/private/compile/cc_compilation_helper.bzl	2026-07-17 15:40:56
++++ b/cc/private/compile/cc_compilation_helper.bzl	2026-07-17 15:40:56
+@@ -310,7 +310,7 @@
+         add_header(path = header.path, visibility = "", can_compile = False)
+         added_paths.add(header.path)
+ 
+-    for header in parameters.public_textual_headers:
++    for header in expanded(parameters.public_textual_headers):
+         if header.path in added_paths:
+             continue
+         add_header(path = header.path, visibility = "", can_compile = False)
+@@ -400,6 +400,7 @@
+     tree_artifacts = [h for h in private_headers if h.is_directory]
+     tree_artifacts += [h for h in public_headers if h.is_directory]
+     tree_artifacts += [h for h in textual_headers if h.is_directory]
++    tree_artifacts += [h for h in public_textual_headers if h.is_directory]
+     content.add_all(tree_artifacts, map_each = lambda x: None, allow_closure = True)
+ 
+     actions.write(module_map.file, content = content, is_executable = True, mnemonic = "CppModuleMap")

--- a/examples/header_modules/patches/0003-do-not-retain-module-map-name-strings.patch
+++ b/examples/header_modules/patches/0003-do-not-retain-module-map-name-strings.patch
@@ -1,0 +1,205 @@
+diff --git a/cc/private/cc_info.bzl b/cc/private/cc_info.bzl
+index a51d0f4..f141c35 100644
+--- a/cc/private/cc_info.bzl
++++ b/cc/private/cc_info.bzl
+@@ -152,23 +152,76 @@ _ModuleMapInfo = provider(
+     "ModuleMapInfo",
+     fields = {
+         "file": "The module map file.",
+-        "name": "The name of the module.",
++        "name": "The name of the module or None if the module is named after the label of the target that generated the module map file (see get_module_map_name).",
+     },
+ )
+ 
+-def create_module_map(*, file, name):
++def create_module_map(*, file, name = None):
+     """
+     Creates a module map struct.
+ 
+     Args:
+         file: The module map file.
+-        name: The name of the module.
++        name: The name of the module. If None (the default), the module is
++          named after the label of the target that generated the module map
++          file. Prefer the default: it avoids retaining a name string per
++          module map as the name is derived on demand from `file.owner`.
+     Returns:
+         A module map struct.
+     """
+     check_private_api()
+     return _ModuleMapInfo(file = file, name = name)
+ 
++def get_module_map_name(module_map):
++    """
++    Returns the name of the module described by a module map struct.
++
++    Module maps generated for a target are named after the target's label,
++    rendered in its unambiguous canonical form, except that main-repository
++    labels do not carry the leading double-at prefix (for example "//pkg:lib"
++    for a main-repository target). Names of targets in external repositories
++    are thus valid label strings, while main-repository names match the
++    traditional module name format.
++
++    Args:
++        module_map: The module map struct.
++    Returns:
++        The name of the module as a string.
++    """
++    if module_map.name != None:
++        return module_map.name
++    label_string = str(module_map.file.owner)
++
++    # buildifier: disable=canonical-repository
++    if label_string.startswith("@@//"):
++        return label_string[2:]
++    return label_string
++
++def get_module_map_label(module_map):
++    """
++    Returns the label a module map struct is named after.
++
++    This is only valid for module maps whose name is (derived from) a label,
++    which is the case for all module maps generated for a target, including
++    separate module maps. It is not valid for module maps with special names
++    such as the crosstool module map.
++
++    Args:
++        module_map: The module map struct.
++    Returns:
++        The Label the module's name refers to.
++    """
++    if module_map.name == None:
++        return module_map.file.owner
++
++    # Module map names of main-repository targets lack the leading "@@" (see
++    # get_module_map_name), which has to be restored for parsing to ensure
++    # that the name is not resolved relative to this file's repository.
++    name = module_map.name
++
++    # buildifier: disable=canonical-repository
++    return Label(name if name.startswith("@") else "@@" + name)
++
+ def create_separate_module_map(module_map):
+     """
+     Creates a separate module map struct.
+@@ -178,7 +231,7 @@ def create_separate_module_map(module_map):
+     Returns:
+         A module map struct.
+     """
+-    return _ModuleMapInfo(file = module_map.file, name = module_map.name + ".sep")
++    return _ModuleMapInfo(file = module_map.file, name = get_module_map_name(module_map) + ".sep")
+ 
+ def create_linking_context(
+         *,
+diff --git a/cc/private/compile/cc_compilation_helper.bzl b/cc/private/compile/cc_compilation_helper.bzl
+index ebc24c7..5c1bfaf 100644
+--- a/cc/private/compile/cc_compilation_helper.bzl
++++ b/cc/private/compile/cc_compilation_helper.bzl
+@@ -21,7 +21,7 @@ load(
+     "repository_exec_path",
+ )
+ load("//cc/common:semantics.bzl", "STRIP_INCLUDE_PREFIX_APPLIES_TO_TEXTUAL_HEADERS", "USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS")
+-load("//cc/private:cc_info.bzl", "create_compilation_context", "create_module_map")
++load("//cc/private:cc_info.bzl", "create_compilation_context", "create_module_map", "get_module_map_name")
+ load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
+ 
+ _VIRTUAL_INCLUDES_DIR = "_virtual_includes"
+@@ -252,7 +252,8 @@ _ModuleMapInfo = provider(
+ def _module_map_struct_to_module_map_content(parameters, tree_expander):
+     lines = []
+     module_map = parameters.module_map
+-    lines.append("module \"%s\" {" % module_map.name)
++    module_name = get_module_map_name(module_map)
++    lines.append("module \"%s\" {" % module_name)
+     lines.append("  export *")
+ 
+     def expanded(artifacts):
+@@ -324,10 +325,10 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
+ 
+     dependency_module_maps = parameters.dependency_module_maps.to_list()
+     for dep in dependency_module_maps:
+-        lines.append("  use \"" + dep.name + "\"")
++        lines.append("  use \"" + get_module_map_name(dep) + "\"")
+ 
+     if parameters.separate_module_headers:
+-        separate_name = module_map.name + ".sep"
++        separate_name = module_name + ".sep"
+         lines.append("  use \"" + separate_name + "\"")
+         lines.append("}")
+         lines.append("module \"" + separate_name + "\" {")
+@@ -341,14 +342,14 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
+             added_paths.add(header.path)
+ 
+         for dep in dependency_module_maps:
+-            lines.append("  use \"" + dep.name + "\"")
++            lines.append("  use \"" + get_module_map_name(dep) + "\"")
+ 
+     lines.append("}")
+ 
+     if parameters.extern_dependencies:
+         for dep in dependency_module_maps:
+             lines.append(
+-                "extern module \"" + dep.name + "\" \"" +
++                "extern module \"" + get_module_map_name(dep) + "\" \"" +
+                 parameters.leading_periods + dep.file.path + "\"",
+             )
+ 
+@@ -561,7 +562,6 @@ def _init_cc_compilation_context(
+         if not module_map:
+             module_map = create_module_map(
+                 file = actions.declare_file(label.name + ".cppmap"),
+-                name = label.workspace_name + "//" + label.package + ":" + label.name,
+             )
+ 
+         # There are different modes for module compilation:
+diff --git a/cc/private/compile/compile.bzl b/cc/private/compile/compile.bzl
+index 3aebb85..faac9aa 100644
+--- a/cc/private/compile/compile.bzl
++++ b/cc/private/compile/compile.bzl
+@@ -36,6 +36,7 @@ load(
+     "create_cc_compilation_context_with_cpp20_modules",
+     "create_compilation_context_with_extra_header_tokens",
+     "create_separate_module_map",
++    "get_module_map_label",
+ )
+ load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
+ load("//cc/private/compile:cc_compilation_helper.bzl", "cc_compilation_helper", "dotd_files_enabled", "serialized_diagnostics_file_enabled")
+@@ -1153,7 +1154,7 @@ def _create_cc_compile_actions(
+ 
+     if _should_provide_header_modules(feature_configuration, private_headers, public_headers):
+         cpp_module_map = cc_compilation_context._module_map
+-        module_map_label = Label(cpp_module_map.name)
++        module_map_label = get_module_map_label(cpp_module_map)
+         modules = _create_module_action(
+             action_construction_context = action_construction_context,
+             cc_compilation_context = cc_compilation_context,
+@@ -2109,7 +2110,7 @@ def _create_module_action(
+         additional_include_scanning_roots,
+         outputs,
+         progress_message_prefix):
+-    module_map_label = Label(cpp_module_map.name)
++    module_map_label = get_module_map_label(cpp_module_map)
+     return _create_pic_nopic_compile_source_actions(
+         action_construction_context = action_construction_context,
+         cc_compilation_context = cc_compilation_context,
+diff --git a/cc/private/compile/compile_build_variables.bzl b/cc/private/compile/compile_build_variables.bzl
+index ed76c6e..caa1a26 100644
+--- a/cc/private/compile/compile_build_variables.bzl
++++ b/cc/private/compile/compile_build_variables.bzl
+@@ -16,6 +16,7 @@ All build variables we create for various `CppCompileAction`s
+ """
+ 
+ load("//cc/common:cc_helper_internal.bzl", "extensions", "get_fdo_build_stamp", "get_linkstamp_stamps", _PRIVATE_STARLARKIFICATION_ALLOWLIST = "PRIVATE_STARLARKIFICATION_ALLOWLIST")
++load("//cc/private:cc_info.bzl", "get_module_map_name")
+ load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
+ load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
+ 
+@@ -319,7 +320,7 @@ def get_specific_compile_build_variables(
+     result = {}
+ 
+     if feature_configuration.is_enabled("module_maps") and cpp_module_map:
+-        result[_VARS.MODULE_NAME] = cpp_module_map.name
++        result[_VARS.MODULE_NAME] = get_module_map_name(cpp_module_map)
+         result[_VARS.MODULE_MAP_FILE] = cpp_module_map.file
+         result[_VARS.DEPENDENT_MODULE_MAP_FILES] = direct_module_maps
+ 

--- a/examples/header_modules/patches/BUILD.bazel
+++ b/examples/header_modules/patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["*"])

--- a/kernel/extension/kernel-headers.BUILD.bazel
+++ b/kernel/extension/kernel-headers.BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
 load("@llvm//:directory.bzl", "headers_directory")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
@@ -13,5 +14,18 @@ cc_library(
 headers_directory(
     name = "kernel_headers_directory",
     path = "include",
+    visibility = ["//visibility:public"],
+)
+
+# The kernel headers as an enumerated list rather than a directory. Used to
+# declare them as `textual header`s in the toolchain's module map, which
+# preserves `layering_check` semantics but doesn't require a compiled module
+# for them in `-fmodules` builds.
+directory(
+    name = "kernel_headers_files",
+    srcs = glob(
+        ["include/**"],
+        allow_empty = True,
+    ),
     visibility = ["//visibility:public"],
 )

--- a/kernel/extension/trampoline.BUILD.bazel
+++ b/kernel/extension/trampoline.BUILD.bazel
@@ -17,3 +17,8 @@ declare_kernel_headers_repository_target(
     name = "kernel_headers_directory",
     target_compatible_with = ["@platforms//os:linux"],
 )
+
+declare_kernel_headers_repository_target(
+    name = "kernel_headers_files",
+    target_compatible_with = ["@platforms//os:linux"],
+)

--- a/runtimes/cxxstdlib/BUILD.bazel
+++ b/runtimes/cxxstdlib/BUILD.bazel
@@ -1,6 +1,58 @@
+load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = ["//visibility:public"])
+
+# The C++ standard library headers, split into the public (includable)
+# headers and the implementation details. The split allows compiling the
+# public headers into a Clang module (see
+# @llvm//toolchain/features/header_modules/libcxx): implementation details
+# include mutually exclusive variants that can't all be compiled into a
+# module, and the C standard library wrappers include the C standard library
+# headers via include_next and thus have to be textual.
+#
+# On macOS, the libc++ headers are copied out of the SDK since files inside
+# the sysroot directory can't be used as headers of a target: the sysroot is
+# staged as a single directory and would collide with them in the sandbox.
+copy_to_directory(
+    name = "macos_cxx_public_headers",
+    srcs = ["@macos_sdk//sysroot:libcxx_public_headers"],
+    include_external_repositories = ["*"],
+    root_paths = ["sysroot/usr/include/c++/v1"],
+)
+
+copy_to_directory(
+    name = "macos_cxx_detail_headers",
+    srcs = ["@macos_sdk//sysroot:libcxx_textual_headers"],
+    include_external_repositories = ["*"],
+    root_paths = ["sysroot/usr/include/c++/v1"],
+)
+
+filegroup(
+    name = "no_headers",
+)
+
+alias(
+    name = "public_headers_directory",
+    actual = select({
+        "@platforms//os:macos": ":macos_cxx_public_headers",
+        ":libstdcxx_linux": "//runtimes/libstdcxx:headers_include_search_directory",
+        ":libstdcxx_windows": ":libstdcxx_windows_unsupported",
+        "//conditions:default": "@llvm-project//libcxx:libcxx_public_headers_directory",
+    }),
+)
+
+alias(
+    name = "detail_headers_directory",
+    actual = select({
+        "@platforms//os:macos": ":macos_cxx_detail_headers",
+        # libstdc++ is not split; all of its headers are in
+        # :public_headers_directory.
+        ":libstdcxx_linux": ":no_headers",
+        ":libstdcxx_windows": ":libstdcxx_windows_unsupported",
+        "//conditions:default": "@llvm-project//libcxx:libcxx_detail_headers_directory",
+    }),
+)
 
 config_setting(
     name = "libcxx_linux",

--- a/runtimes/glibc/BUILD.bazel
+++ b/runtimes/glibc/BUILD.bazel
@@ -127,6 +127,12 @@ alias(
 )
 
 alias(
+    name = "glibc_headers_files",
+    actual = "@glibc//:glibc_headers_files",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "glibc_Scrt1.object",
     actual = "@glibc//:glibc_Scrt1.object",
     visibility = ["//visibility:public"],

--- a/runtimes/glibc/extension/glibc-headers.BUILD.bazel
+++ b/runtimes/glibc/extension/glibc-headers.BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
 load("@llvm//:directory.bzl", "headers_directory")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
@@ -14,5 +15,18 @@ cc_library(
 headers_directory(
     name = "glibc_headers_directory",
     path = "include",
+    visibility = ["//visibility:public"],
+)
+
+# The glibc headers as an enumerated list rather than a directory. Used to
+# declare them as `textual header`s in the toolchain's module map, which
+# preserves `layering_check` semantics but doesn't require a compiled module
+# for them in `-fmodules` builds.
+directory(
+    name = "glibc_headers_files",
+    srcs = glob(
+        ["include/**"],
+        allow_empty = True,
+    ),
     visibility = ["//visibility:public"],
 )

--- a/runtimes/glibc/extension/trampoline.BUILD.bazel
+++ b/runtimes/glibc/extension/trampoline.BUILD.bazel
@@ -15,6 +15,12 @@ alias(
 )
 
 alias(
+    name = "glibc_headers_files",
+    actual = make_select_glibc_repository_target("@glibc_headers", "glibc_headers_files"),
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+alias(
     name = "glibc_c_nonshared.static",
     actual = make_select_glibc_repository_target("@glibc", "c_nonshared"),
     target_compatible_with = ["@platforms//os:linux"],

--- a/runtimes/module_map.bzl
+++ b/runtimes/module_map.bzl
@@ -35,11 +35,12 @@ def _module_map_impl(ctx):
         expand_directories = False,
     )
 
+    # Tree artifacts among the textual headers are expanded to their
+    # constituent files at execution time.
     module_map_args.add_joined(
         include_path_info.textual_headers,
         join_with = "\n",
         format_each = "  textual header \"%s\"",
-        expand_directories = False,
     )
 
     module_map_args.add("}")
@@ -58,8 +59,9 @@ def _module_map_impl(ctx):
 module_map = rule(
     doc = """Generates a Clang module map for the toolchain and system headers.
 
-    Source and output directories are included as umbrella submodules.
-    Individual header files (typically `run_binary` outputs like in mingw) are included as textual headers.""",
+    Source directories are included as umbrella submodules.
+    Individual header files and the contents of output directories (Tree
+    Artifacts) are included as textual headers.""",
     implementation = _module_map_impl,
     attrs = {
         "include_path": attr.label(
@@ -74,11 +76,19 @@ def _include_path_impl(ctx):
     textual_headers_depsets = []
 
     for src in ctx.attr.srcs:
-        if SourceDirectoryInfo in src or DirectoryInfo not in src:
-            # We're either a source directory or an output directory (Tree Artifact).
+        if SourceDirectoryInfo in src:
+            # Source directories are opaque even at execution time, so they
+            # can only be covered by umbrella submodules.
             submodule_directories.append(src[DefaultInfo].files)
-        else:
+        elif DirectoryInfo in src:
             textual_headers_depsets.append(src[DirectoryInfo].transitive_files)
+        else:
+            # Output directories (tree artifacts) are expanded to their
+            # constituent files when the module map is written. Declaring
+            # headers as textual rather than covering them with umbrella
+            # submodules preserves `layering_check` semantics, but doesn't
+            # require a compiled module for them in `-fmodules` builds.
+            textual_headers_depsets.append(src[DefaultInfo].files)
 
     return [
         IncludePathInfo(

--- a/tests/header_modules/BUILD.bazel
+++ b/tests/header_modules/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load(":defs.bzl", "header_modules_test_targets")
+
+# All targets in this package compile their headers into Clang header modules
+# (.pcm files) and import their dependencies' modules instead of parsing their
+# headers textually.
+package(features = [
+    "header_modules",
+    "use_header_modules",
+    "layering_check",
+])
+
+header_modules_test_targets()
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_features//:features",
+        "@rules_cc//cc:core_rules",
+    ],
+)

--- a/tests/header_modules/counter.cc
+++ b/tests/header_modules/counter.cc
@@ -1,0 +1,5 @@
+#include "tests/header_modules/counter.h"
+
+void Counter::Increment() { ++value_; }
+
+int Counter::Value() const { return value_; }

--- a/tests/header_modules/counter.h
+++ b/tests/header_modules/counter.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class Counter {
+ public:
+  void Increment();
+  int Value() const;
+
+ private:
+  int value_ = 0;
+};

--- a/tests/header_modules/defs.bzl
+++ b/tests/header_modules/defs.bzl
@@ -1,0 +1,33 @@
+"""Test targets for Clang header modules."""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+def header_modules_test_targets():
+    """Declares the test targets for Clang header modules.
+
+    Header modules are only supported with the Starlark implementation of the
+    C++ rules, so no targets are declared with Bazel versions that don't
+    provide it.
+    """
+    if not bazel_features.cc.supports_starlarkified_toolchains:
+        return
+
+    cc_library(
+        name = "counter",
+        srcs = ["counter.cc"],
+        hdrs = ["counter.h"],
+    )
+
+    cc_library(
+        name = "double_counter",
+        hdrs = ["double_counter.h"],
+        deps = [":counter"],
+    )
+
+    cc_test(
+        name = "main_test",
+        srcs = ["main_test.cc"],
+        deps = [":double_counter"],
+    )

--- a/tests/header_modules/defs.bzl
+++ b/tests/header_modules/defs.bzl
@@ -31,3 +31,19 @@ def header_modules_test_targets():
         srcs = ["main_test.cc"],
         deps = [":double_counter"],
     )
+
+    # Targets with system includes work without compiled modules for them:
+    # system headers are declared as textual headers in the toolchain's module
+    # map and are parsed textually even in `-fmodules` builds.
+
+    cc_library(
+        name = "textual_greeter",
+        srcs = ["greeter.cc"],
+        hdrs = ["greeter.h"],
+    )
+
+    cc_test(
+        name = "greeter_textual_test",
+        srcs = ["greeter_main.cc"],
+        deps = [":textual_greeter"],
+    )

--- a/tests/header_modules/defs.bzl
+++ b/tests/header_modules/defs.bzl
@@ -47,3 +47,50 @@ def header_modules_test_targets():
         srcs = ["greeter_main.cc"],
         deps = [":textual_greeter"],
     )
+
+    # With a dependency on the libcxx target, the C++ standard library headers
+    # are instead imported as a compiled module.
+
+    cc_library(
+        name = "greeter",
+        srcs = ["greeter.cc"],
+        hdrs = ["greeter.h"],
+        deps = ["@llvm//toolchain/features/header_modules/libcxx"],
+    )
+
+    cc_test(
+        name = "greeter_test",
+        srcs = ["greeter_main.cc"],
+        deps = [
+            ":greeter",
+            "@llvm//toolchain/features/header_modules/libcxx",
+        ],
+    )
+
+    # With module codegen (matching Google's toolchain), modules are built
+    # with local submodule visibility and compiled into object files that
+    # provide the template instantiations triggered inside the module, which
+    # importing translation units then no longer emit.
+
+    codegen_features = [
+        "header_module_codegen",
+        "header_modules_codegen_functions",
+    ]
+
+    cc_library(
+        name = "item_store",
+        srcs = ["item_store.cc"],
+        hdrs = ["item_store.h"],
+        features = codegen_features,
+        deps = ["@llvm//toolchain/features/header_modules/libcxx"],
+    )
+
+    cc_test(
+        name = "item_store_test",
+        srcs = ["item_store_main.cc"],
+        features = codegen_features,
+        deps = [
+            ":item_store",
+            "@llvm//toolchain/features/header_modules/libcxx",
+        ],
+    )

--- a/tests/header_modules/double_counter.h
+++ b/tests/header_modules/double_counter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "tests/header_modules/counter.h"
+
+class DoubleCounter {
+ public:
+  void Increment() {
+    counter_.Increment();
+    counter_.Increment();
+  }
+
+  int Value() const { return counter_.Value(); }
+
+ private:
+  Counter counter_;
+};

--- a/tests/header_modules/greeter.cc
+++ b/tests/header_modules/greeter.cc
@@ -1,0 +1,17 @@
+#include "tests/header_modules/greeter.h"
+
+namespace {
+size_t count = 0;
+}
+
+std::string greet(const std::vector<std::string>& names) {
+  ++count;
+  std::string greeting = "Hello";
+  for (const std::string& name : names) {
+    greeting += ", " + name;
+  }
+  greeting += "!";
+  return greeting;
+}
+
+size_t greeting_count() { return count; }

--- a/tests/header_modules/greeter.h
+++ b/tests/header_modules/greeter.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stddef.h>
+
+#include <string>
+#include <vector>
+
+std::string greet(const std::vector<std::string>& names);
+
+size_t greeting_count();

--- a/tests/header_modules/greeter_main.cc
+++ b/tests/header_modules/greeter_main.cc
@@ -1,0 +1,12 @@
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "tests/header_modules/greeter.h"
+
+int main() {
+  std::string greeting = greet({"header", "modules"});
+  std::printf("%s\n", greeting.c_str());
+  return greeting == "Hello, header, modules!" && greeting_count() == 1 ? 0
+                                                                        : 1;
+}

--- a/tests/header_modules/item_store.cc
+++ b/tests/header_modules/item_store.cc
@@ -1,0 +1,13 @@
+#include "tests/header_modules/item_store.h"
+
+#include <sstream>
+
+namespace item_store {
+
+std::string Describe(const Item& item) {
+  std::ostringstream oss;
+  oss << item.name << "(" << item.values.size() << ")";
+  return oss.str();
+}
+
+}  // namespace item_store

--- a/tests/header_modules/item_store.h
+++ b/tests/header_modules/item_store.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace item_store {
+
+struct Item {
+  std::string name;
+  std::vector<int> values;
+};
+
+std::string Describe(const Item& item);
+
+// Instantiates std::vector<Item> member functions inside this module: with
+// module codegen, importing translation units rely on the object file
+// compiled from this module to provide them.
+inline std::vector<Item> MakeItems(int n) {
+  std::vector<Item> items;
+  items.reserve(static_cast<size_t>(n));
+  for (int i = 0; i < n; ++i) {
+    Item item;
+    item.name = "item" + std::to_string(i);
+    item.values.assign(static_cast<size_t>(i) + 1, i);
+    items.push_back(std::move(item));
+  }
+  return items;
+}
+
+}  // namespace item_store

--- a/tests/header_modules/item_store_main.cc
+++ b/tests/header_modules/item_store_main.cc
@@ -1,0 +1,13 @@
+#include <cstdio>
+#include <string>
+
+#include "tests/header_modules/item_store.h"
+
+int main() {
+  std::string summary;
+  for (const auto& item : item_store::MakeItems(3)) {
+    summary += item_store::Describe(item);
+  }
+  std::printf("%s\n", summary.c_str());
+  return summary == "item0(1)item1(2)item2(3)" ? 0 : 1;
+}

--- a/tests/header_modules/main_test.cc
+++ b/tests/header_modules/main_test.cc
@@ -1,0 +1,8 @@
+#include "tests/header_modules/double_counter.h"
+
+int main() {
+  DoubleCounter counter;
+  counter.Increment();
+  counter.Increment();
+  return counter.Value() == 4 ? 0 : 1;
+}

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -264,6 +264,7 @@ cc_args_list(
     args = [
         "//toolchain/args/macos:macos_minimum_os_flags",
         "//toolchain/args/macos:macos_default_framework_flags",
+        "//toolchain/args:macos_cxxstdlib_headers_include_search_paths",
     ] + select({
         # Only expose the sanitizer interface headers when compiling user
         # programs (runtime_stage=complete), not when building the compiler-rt
@@ -278,9 +279,10 @@ cc_args_list(
 # TODO(zbarsky): This must match llvm/toolchains/llvm.bzl
 cc_args_list(
     name = "linux_toolchain_args",
-    args = [
-        "//toolchain/args:cxxstdlib_headers_include_search_paths",
-    ] + select({
+    args = select({
+        "//runtimes/cxxstdlib:libstdcxx_linux": ["//toolchain/args:cxxstdlib_headers_include_search_paths"],
+        "//conditions:default": ["//toolchain/args:split_cxxstdlib_headers_include_search_paths"],
+    }) + select({
         "//platforms/config:musl": [
             "//toolchain/args/linux:kernel_headers_include_search_paths",
             "//toolchain/args/linux:musl_libc_headers_include_search_paths",
@@ -306,8 +308,10 @@ cc_args_list(
 # TODO(zbarsky): This must match llvm/toolchains/llvm.bzl
 cc_args_list(
     name = "windows_toolchain_args",
-    args = [
-        "//toolchain/args:cxxstdlib_headers_include_search_paths",
+    args = select({
+        "//runtimes/cxxstdlib:libstdcxx_windows": ["//toolchain/args:cxxstdlib_headers_include_search_paths"],
+        "//conditions:default": ["//toolchain/args:split_cxxstdlib_headers_include_search_paths"],
+    }) + [
         "//toolchain/args/windows:mingw_headers_include_search_paths",
     ],
 )

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -125,6 +125,75 @@ cc_args(
     ],
 )
 
+# The C++ standard library headers, split into the public headers (which can
+# be compiled into a Clang module) and the implementation details (see
+# //runtimes/cxxstdlib). On macOS, -nostdinc++ prevents the compiler from
+# also finding the copies in the SDK sysroot: mixing them breaks the
+# include_next chains of the C standard library wrapper headers since the
+# include guards of the copies short-circuit the originals.
+cc_args(
+    name = "macos_cxxstdlib_headers_include_search_paths",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:linkstamp_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
+        "@rules_cc//cc/toolchains/actions:cpp_module_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_module_codegen",
+        "@rules_cc//cc/toolchains/actions:clif_match",
+        "@rules_cc//cc/toolchains/actions:objcpp_compile",
+    ],
+    args = [
+        "-nostdinc++",
+        "-isystem",
+        "{cxx_public_headers_include_search_path}",
+        "-isystem",
+        "{cxx_detail_headers_include_search_path}",
+    ],
+    # Do not sort: keep the data order aligned with the argument order above.
+    data = [
+        "//runtimes/cxxstdlib:public_headers_directory",
+        "//runtimes/cxxstdlib:detail_headers_directory",
+    ],
+    format = {
+        "cxx_public_headers_include_search_path": "//runtimes/cxxstdlib:public_headers_directory",
+        "cxx_detail_headers_include_search_path": "//runtimes/cxxstdlib:detail_headers_directory",
+    },
+)
+
+cc_args(
+    name = "split_cxxstdlib_headers_include_search_paths",
+    actions = [
+        # cpp_compile_actions - lto_backend
+        # Omitted to avoid unused arg warning for -I paths.
+        "@rules_cc//cc/toolchains/actions:linkstamp_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
+        "@rules_cc//cc/toolchains/actions:cpp_module_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_module_codegen",
+        "@rules_cc//cc/toolchains/actions:clif_match",
+        "@rules_cc//cc/toolchains/actions:objcpp_compile",
+    ],
+    args = [
+        "-isystem",
+        "{cxx_public_headers_include_search_path}",
+        "-isystem",
+        "{cxx_detail_headers_include_search_path}",
+        "-isystem",
+        "{cxxstdlib_abi_headers_include_search_path}",
+    ],
+    # Do not sort: keep the data order aligned with the argument order above.
+    data = [
+        "//runtimes/cxxstdlib:public_headers_directory",
+        "//runtimes/cxxstdlib:detail_headers_directory",
+        "//runtimes/cxxstdlib:abi_headers_include_search_directory",
+    ],
+    format = {
+        "cxx_public_headers_include_search_path": "//runtimes/cxxstdlib:public_headers_directory",
+        "cxx_detail_headers_include_search_path": "//runtimes/cxxstdlib:detail_headers_directory",
+        "cxxstdlib_abi_headers_include_search_path": "//runtimes/cxxstdlib:abi_headers_include_search_directory",
+    },
+)
+
 cc_args(
     name = "cxxstdlib_headers_include_search_paths",
     actions = [

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -97,6 +97,34 @@ cc_args(
     ],
 )
 
+# These args need to be bound to the action type rather than carried by a
+# feature (like `use_header_modules` in
+# //toolchain/features/header_modules) because `-x` only applies to inputs
+# that come after it on the command line: args attached to the action config
+# render before the `-c <source>` emitted by the legacy features, while args
+# from non-enabled toolchain features render after it. Module compile actions
+# are only created for targets with the `header_modules` feature enabled, so
+# these args never affect other builds.
+cc_args(
+    name = "header_module_compile",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:cpp_module_compile",
+    ],
+    args = [
+        "-xc++",
+        "-Xclang",
+        "-emit-module",
+        "-Xclang",
+        "-fmodules-embed-all-files",
+        # Note: -fmodules-local-submodule-visibility is deliberately not
+        # passed: with it, Clang expects template instantiations triggered
+        # inside a module to be provided by an object file compiled from the
+        # module (the header_module_codegen feature) and does not emit them in
+        # importing translation units, which results in undefined symbols at
+        # link time.
+    ],
+)
+
 cc_args(
     name = "cxxstdlib_headers_include_search_paths",
     actions = [

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -10,6 +10,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "@llvm//toolchain/features:static_link_cpp_runtimes",
             "@llvm//toolchain/features/runtime_library_search_directories:feature",
             "@llvm//toolchain/features:parse_headers",
+            "@llvm//toolchain/features/header_modules:all_header_module_features",
             "@llvm//toolchain/features:external_include_paths",
             "@llvm//toolchain/features:generate_pdb_file",
             "@llvm//toolchain/features:fdo_optimize",
@@ -95,6 +96,9 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         }) + [
             # TODO: rules_cc passes extra args to these actions, ideally these would be fixed in rules_cc.
             "@llvm//toolchain/args:ignore_unused_command_line_argument",
+            # Only affects cpp_module_compile actions, which are only created
+            # for targets with the `header_modules` feature enabled.
+            "@llvm//toolchain/args:header_module_compile",
         ] + extra_args,
         supports_header_parsing = True,
         supports_param_files = True,

--- a/toolchain/features/header_modules/BUILD.bazel
+++ b/toolchain/features/header_modules/BUILD.bazel
@@ -1,0 +1,126 @@
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
+
+package(default_visibility = ["//visibility:public"])
+
+# Based on https://github.com/bazelbuild/bazel/issues/4005#issuecomment-1212952697.
+#
+# Features that control header modules.
+#
+# We have different features for module consumers and producers:
+# 'header_modules' is enabled for targets that support being compiled as a
+# header module.
+# 'use_header_modules' is enabled for targets that want to use the provided
+# header modules from their transitive closure. We enable this globally and
+# disable it for targets that do not support builds with header modules.
+#
+# Allow switching off header modules completely by specifying
+# features=["-use_header_modules"] in a rule.
+
+_MODULE_CONSUMING_ACTIONS = [
+    "@rules_cc//cc/toolchains/actions:cpp_compile",
+    "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
+    "@rules_cc//cc/toolchains/actions:cpp_module_compile",
+]
+
+# The args for the cpp_module_compile action itself live in
+# //toolchain/args:header_module_compile since they include the positional
+# `-x` flag, which has to be attached to the action config to end up before
+# the source file on the command line.
+cc_feature(
+    name = "header_modules",
+    feature_name = "header_modules",
+    requires_any_of = [":use_header_modules"],
+)
+
+cc_feature(
+    name = "header_module_codegen",
+    feature_name = "header_module_codegen",
+    requires_any_of = [":header_modules"],
+)
+
+cc_args(
+    name = "header_modules_codegen_functions_args",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_module_compile"],
+    args = [
+        "-Xclang",
+        "-fmodules-codegen",
+    ],
+)
+
+cc_feature(
+    name = "header_modules_codegen_functions",
+    args = [":header_modules_codegen_functions_args"],
+    feature_name = "header_modules_codegen_functions",
+    implies = [":header_module_codegen"],
+)
+
+cc_args(
+    name = "header_modules_codegen_debuginfo_args",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_module_compile"],
+    args = [
+        "-Xclang",
+        "-fmodules-debuginfo",
+    ],
+)
+
+cc_feature(
+    name = "header_modules_codegen_debuginfo",
+    args = [":header_modules_codegen_debuginfo_args"],
+    feature_name = "header_modules_codegen_debuginfo",
+    implies = [":header_module_codegen"],
+)
+
+cc_args(
+    name = "use_header_modules_args",
+    actions = _MODULE_CONSUMING_ACTIONS,
+    args = [
+        "-fmodules",
+        "-fmodule-file-deps",
+        "-fno-implicit-modules",
+        "-fno-implicit-module-maps",
+        "-Wno-modules-ambiguous-internal-linkage",
+        "-Wno-module-import-in-extern-c",
+        "-Wno-modules-import-nested-redundant",
+    ],
+)
+
+cc_args(
+    name = "use_header_modules_module_files_args",
+    actions = _MODULE_CONSUMING_ACTIONS,
+    args = [
+        "-Xclang",
+        "-fmodule-file={module_files}",
+    ],
+    format = {
+        "module_files": "@rules_cc//cc/toolchains/variables:module_files",
+    },
+    iterate_over = "@rules_cc//cc/toolchains/variables:module_files",
+    requires_not_none = "@rules_cc//cc/toolchains/variables:module_files",
+)
+
+cc_feature(
+    name = "use_header_modules",
+    args = [
+        # Module compiles require the module name, but rules_cc only passes
+        # it as part of the layering_check feature, which is not necessarily
+        # enabled together with this feature. Passing it twice is harmless.
+        "@rules_cc//cc/toolchains/args/layering_check:module_name_args",
+        ":use_header_modules_args",
+        ":use_header_modules_module_files_args",
+    ],
+    feature_name = "use_header_modules",
+    implies = ["@rules_cc//cc/toolchains/args/layering_check:use_module_maps"],
+)
+
+cc_feature_set(
+    name = "all_header_module_features",
+    all_of = [
+        ":header_modules",
+        ":header_module_codegen",
+        ":header_modules_codegen_functions",
+        ":header_modules_codegen_debuginfo",
+        ":use_header_modules",
+    ],
+)

--- a/toolchain/features/header_modules/BUILD.bazel
+++ b/toolchain/features/header_modules/BUILD.bazel
@@ -19,7 +19,16 @@ package(default_visibility = ["//visibility:public"])
 # features=["-use_header_modules"] in a rule.
 #
 # System headers are declared as textual headers in the toolchain's module
-# map and thus never require a compiled module.
+# map and thus never require a compiled module. The exception is the C++
+# standard library: targets should depend on
+# //toolchain/features/header_modules/libcxx so that its public headers are
+# compiled into a module and imported instead of being textually absorbed
+# into every module. Without the dependency, each header module textually
+# absorbs its own copy of the C++ standard library declarations, and Clang's
+# merging of these copies in importing translation units is known to fail
+# with errors like "'std::length_error::length_error' from module A is not
+# present in definition of 'std::length_error' in module B" once several
+# modules are imported together.
 #
 # Headers that are only available as opaque source directories and are not
 # enumerated as textual headers in the toolchain's module map (e.g. the Linux

--- a/toolchain/features/header_modules/BUILD.bazel
+++ b/toolchain/features/header_modules/BUILD.bazel
@@ -17,11 +17,22 @@ package(default_visibility = ["//visibility:public"])
 #
 # Allow switching off header modules completely by specifying
 # features=["-use_header_modules"] in a rule.
+#
+# System headers are declared as textual headers in the toolchain's module
+# map and thus never require a compiled module.
+#
+# Headers that are only available as opaque source directories and are not
+# enumerated as textual headers in the toolchain's module map (e.g. the Linux
+# kernel headers and macOS frameworks) are covered by umbrella submodules,
+# which can't be included in `-fmodules` builds without a compiled module.
 
 _MODULE_CONSUMING_ACTIONS = [
     "@rules_cc//cc/toolchains/actions:cpp_compile",
     "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
     "@rules_cc//cc/toolchains/actions:cpp_module_compile",
+    # Compiling a module to an object file loads the module file, which in
+    # turn loads the module files it imports.
+    "@rules_cc//cc/toolchains/actions:cpp_module_codegen",
 ]
 
 # The args for the cpp_module_compile action itself live in
@@ -34,8 +45,34 @@ cc_feature(
     requires_any_of = [":use_header_modules"],
 )
 
+# Building modules with local submodule visibility parses each header in its
+# own submodule scope, which prevents declarations and macros from leaking
+# between the headers of a module. Clang then also expects template
+# instantiations triggered inside a module to be provided by an object file
+# compiled from the module instead of emitting them in importing translation
+# units, so the flag must only be used together with module codegen (matching
+# Google's toolchain).
+cc_args(
+    name = "local_submodule_visibility_args",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_module_compile"],
+    args = [
+        "-Xclang",
+        "-fmodules-local-submodule-visibility",
+    ],
+)
+
+# Generates one submodule per header in the target's module map, so that
+# each header is parsed in its own scope when the module is compiled with
+# local submodule visibility.
+cc_feature(
+    name = "generate_submodules",
+    feature_name = "generate_submodules",
+    requires_any_of = [":header_modules"],
+)
+
 cc_feature(
     name = "header_module_codegen",
+    args = [":local_submodule_visibility_args"],
     feature_name = "header_module_codegen",
     requires_any_of = [":header_modules"],
 )
@@ -118,6 +155,7 @@ cc_feature_set(
     name = "all_header_module_features",
     all_of = [
         ":header_modules",
+        ":generate_submodules",
         ":header_module_codegen",
         ":header_modules_codegen_functions",
         ":header_modules_codegen_debuginfo",

--- a/toolchain/features/header_modules/libcxx/BUILD.bazel
+++ b/toolchain/features/header_modules/libcxx/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# The C++ standard library as an ordinary cc_library whose public headers are
+# compiled into a Clang module by the regular header module machinery,
+# matching Google's setup for their standard library. C++ targets that
+# include C++ standard library headers in builds with the use_header_modules
+# feature enabled need to depend on this target:
+#
+# - Its generated module map declares the public standard library headers as
+#   modular, taking precedence over the textual declarations in the
+#   toolchain's module map, so that they are compiled once into a module and
+#   imported instead of being textually absorbed into every module (which is
+#   known to trip up Clang's declaration merging once several such modules
+#   are imported together).
+# - The dependency makes generated module maps of depending targets declare
+#   the module as used, which layering_check requires.
+#
+# The implementation detail headers stay textual: they include mutually
+# exclusive variants that can't all be compiled into a module, and the C
+# standard library wrappers include the C standard library headers via
+# include_next.
+#
+# The headers resolve to the same files that the toolchain provides via its
+# include search paths, so targets without this dependency simply keep
+# parsing them textually.
+cc_library(
+    name = "libcxx",
+    hdrs = ["//runtimes/cxxstdlib:public_headers_directory"],
+    features = [
+        # Compile the public headers into a module regardless of the features
+        # of the depending targets' packages.
+        "header_modules",
+        "use_header_modules",
+        # Parse each header in its own submodule with local submodule
+        # visibility so that the headers are isolated from each other, and
+        # compile the module into an object file that provides the inline
+        # functions and template instantiations triggered inside the module
+        # (which importing translation units then reference instead of
+        # emitting their own copies). The three features are interdependent:
+        # without local submodule visibility, textual headers absorbed into
+        # one submodule are not visible to the others, and with it, module
+        # codegen has to provide the module-owned instantiations.
+        "generate_submodules",
+        "header_module_codegen",
+        "header_modules_codegen_functions",
+    ],
+    tags = [
+        # Only used together with the header_modules feature, which requires
+        # the Starlark implementation of the C++ rules.
+        "manual",
+    ],
+    textual_hdrs = ["//runtimes/cxxstdlib:detail_headers_directory"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -310,6 +310,10 @@ def declare_llvm_targets(*, suffix = ""):
             # Explicit textual entries win over the sysroot umbrella above, so
             # C library headers stay textual even in `-fmodules` builds.
             "@macos_sdk//sysroot:c_headers",
+            # The C++ standard library headers as provided via the include
+            # search paths (-nostdinc++ replaces the copies in the SDK).
+            "@llvm//runtimes/cxxstdlib:public_headers_directory",
+            "@llvm//runtimes/cxxstdlib:detail_headers_directory",
         ],
     )
 
@@ -320,7 +324,8 @@ def declare_llvm_targets(*, suffix = ""):
             ":builtin_resource_headers",
         ] + select({
             "@llvm//toolchain:runtimes_all": [
-                "@llvm//runtimes/cxxstdlib:headers_include_search_directory",
+                "@llvm//runtimes/cxxstdlib:public_headers_directory",
+                "@llvm//runtimes/cxxstdlib:detail_headers_directory",
                 "@llvm//runtimes/cxxstdlib:abi_headers_include_search_directory",
             ],
             "//conditions:default": [],
@@ -350,7 +355,8 @@ def declare_llvm_targets(*, suffix = ""):
             ":builtin_resource_headers",
         ] + select({
             "@llvm//toolchain:runtimes_all": [
-                "@llvm//runtimes/cxxstdlib:headers_include_search_directory",
+                "@llvm//runtimes/cxxstdlib:public_headers_directory",
+                "@llvm//runtimes/cxxstdlib:detail_headers_directory",
                 "@llvm//runtimes/cxxstdlib:abi_headers_include_search_directory",
             ],
             "//conditions:default": [],

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -1,4 +1,5 @@
 load("@bazel_features//:features.bzl", "bazel_features")
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
 load("@llvm//runtimes:module_map.bzl", "include_path", "module_map")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
@@ -14,6 +15,18 @@ def declare_llvm_targets(*, suffix = ""):
         name = "builtin_resource_dir",
         # Grab whichever version-specific dir is there.
         path = native.glob(["lib/clang/*"], exclude_directories = 0)[0],
+        visibility = ["//visibility:public"],
+    )
+
+    # The builtin headers as an enumerated list rather than a directory. Used
+    # to declare them as `textual header`s in the toolchain's module map:
+    # umbrella submodules would require Clang to parse every header when the
+    # "crosstool" module is compiled, which fails for headers that are not
+    # standalone-parseable (e.g. the CUDA wrapper headers). Textual headers
+    # are only parsed when included and never require a compiled module.
+    directory(
+        name = "builtin_resource_headers",
+        srcs = native.glob(["lib/clang/*/include/**"]),
         visibility = ["//visibility:public"],
     )
 
@@ -292,8 +305,11 @@ def declare_llvm_targets(*, suffix = ""):
     include_path(
         name = "macos_target_headers",
         srcs = [
-            ":builtin_resource_dir",
+            ":builtin_resource_headers",
             "@macos_sdk//sysroot",
+            # Explicit textual entries win over the sysroot umbrella above, so
+            # C library headers stay textual even in `-fmodules` builds.
+            "@macos_sdk//sysroot:c_headers",
         ],
     )
 
@@ -301,7 +317,7 @@ def declare_llvm_targets(*, suffix = ""):
     include_path(
         name = "linux_target_headers",
         srcs = [
-            ":builtin_resource_dir",
+            ":builtin_resource_headers",
         ] + select({
             "@llvm//toolchain:runtimes_all": [
                 "@llvm//runtimes/cxxstdlib:headers_include_search_directory",
@@ -309,14 +325,20 @@ def declare_llvm_targets(*, suffix = ""):
             ],
             "//conditions:default": [],
         }) + [
-            "@kernel_headers//:kernel_headers_directory",
+            # The enumerated variant of the kernel headers so that they are
+            # declared as textual headers rather than covered by an umbrella
+            # submodule.
+            "@kernel_headers//:kernel_headers_files",
             "@llvm//sanitizers:sanitizers_headers_include_search_directory",
         ] + select({
             "@llvm//platforms/config:musl": [
                 "@llvm//runtimes/musl:musl_headers_include_search_directory",
             ],
             "@llvm//platforms/config:gnu": [
-                "@llvm//runtimes/glibc:glibc_headers_include_search_directory",
+                # The enumerated variant of the glibc headers so that they
+                # are declared as textual headers rather than covered by an
+                # umbrella submodule.
+                "@llvm//runtimes/glibc:glibc_headers_files",
             ],
         }),
     )
@@ -325,7 +347,7 @@ def declare_llvm_targets(*, suffix = ""):
     include_path(
         name = "windows_target_headers",
         srcs = [
-            ":builtin_resource_dir",
+            ":builtin_resource_headers",
         ] + select({
             "@llvm//toolchain:runtimes_all": [
                 "@llvm//runtimes/cxxstdlib:headers_include_search_directory",
@@ -343,7 +365,7 @@ def declare_llvm_targets(*, suffix = ""):
     include_path(
         name = "wasm_target_headers",
         srcs = [
-            ":builtin_resource_dir",
+            ":builtin_resource_headers",
             # TODO(zbarsky): We'll want to add wasi libc headers here.
         ],
     )


### PR DESCRIPTION
Umbrella branch that stacks the header modules PRs for testing them together: #740 (the `header_modules`/`use_header_modules`/`header_module_codegen` features), #760 (system headers as textual headers in the toolchain's module map), #762 (size attributes for those, written by a small C tool), #764 (the C++ standard library as a Clang module, attached to every C++ target through the `cc_runtimes` toolchain) and, on top, an example workspace under `examples/header_modules`. The individual PRs carry the descriptions; this one is not meant to be merged as is.

Usage, requiring Bazel 9.3.0 or later:

```starlark
package(features = ["header_modules", "use_header_modules", "layering_check"])
# Optionally per target: features = ["header_module_codegen", "header_modules_codegen_functions"]
```

No flags and no explicit dependencies: the standard library module is built on demand for targets that import modules, everything else keeps parsing system headers textually. Targets whose language options diverge from the configuration-wide defaults (e.g. via per-target `copts` such as `-std=` or `-fno-exceptions`) can't load the shared modules and need `features = ["-use_header_modules"]`.

On a benchmark of 96 translation units importing 48 modules (M3 Max, sandboxed), a full rebuild with 16 jobs takes 6s instead of 21s, a serial one 27s instead of 51s, and editing one header included by 16 consumers 2.5s instead of 8s; details in #762 and #764.
