### PR TITLE
Support libFuzzer on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,8 +160,9 @@ jobs:
             --remote_header=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
             //:main_default
 
-      # ASan and UBSan are fully supported on macOS: run their e2e tests (they
-      # execute locally — no remote executor is configured for macOS).
+      # ASan, UBSan and libFuzzer are fully supported on macOS: run their e2e
+      # tests (they execute locally — no remote executor is configured for
+      # macOS).
       # TSan and LSan build, link and load on macOS, but their runtime support
       # is a follow-up, so we only validate that their instrumented binaries
       # build (the runtime e2e tests stay Linux-only).
@@ -176,7 +177,10 @@ jobs:
             test \
             --remote_header=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
             //:asan_output_test \
-            //:ubsan_output_test
+            //:ubsan_output_test \
+            //:fuzzer_output_test \
+            //:fuzzer_asan_output_test \
+            //:fuzzer_ubsan_output_test
           bazel \
             --bazelrc=.bazelrc \
             build \

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -1039,6 +1039,7 @@ fuzzer_cc_binary(
     srcs = ["fuzzer_main.cc"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
@@ -1064,6 +1065,7 @@ exec_test(
     tags = ["no-remote"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
@@ -1073,6 +1075,7 @@ fuzzer_asan_cc_binary(
     srcs = ["fuzzer_asan_main.cc"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
@@ -1091,6 +1094,7 @@ exec_test(
     tags = ["no-remote"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
@@ -1100,6 +1104,7 @@ fuzzer_cc_binary(
     srcs = ["fuzzer_ubsan_main.cc"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
@@ -1118,6 +1123,7 @@ exec_test(
     tags = ["no-remote"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )

--- a/e2e/rules_cc/defs.bzl
+++ b/e2e/rules_cc/defs.bzl
@@ -189,7 +189,8 @@ xray_cc_binary, _xray_cc_binary_internal = with_cfg(cc_binary).set(
     True,
 ).build()
 
-fuzzer_cc_binary, _fuzzer_cc_binary_internal = with_cfg(cc_binary).set(
+# buildifier: disable=unused-variable
+_fuzzer_cc_binary, _fuzzer_cc_binary_internal = with_cfg(cc_binary).set(
     Label("@llvm//config:fuzzer"),
     True,
 ).set(
@@ -203,7 +204,13 @@ fuzzer_cc_binary, _fuzzer_cc_binary_internal = with_cfg(cc_binary).set(
     True,
 ).build()
 
-fuzzer_asan_cc_binary, _fuzzer_asan_cc_binary_internal = with_cfg(cc_binary).set(
+fuzzer_cc_binary = _with_macos_sanitizer_runtime(
+    _fuzzer_cc_binary,
+    "@llvm//runtimes/compiler-rt:clang_rt.ubsan_standalone.shared",
+)
+
+# buildifier: disable=unused-variable
+_fuzzer_asan_cc_binary, _fuzzer_asan_cc_binary_internal = with_cfg(cc_binary).set(
     Label("@llvm//config:fuzzer"),
     True,
 ).set(
@@ -216,6 +223,11 @@ fuzzer_asan_cc_binary, _fuzzer_asan_cc_binary_internal = with_cfg(cc_binary).set
     Label("@llvm//config:host_asan"),
     True,
 ).build()
+
+fuzzer_asan_cc_binary = _with_macos_sanitizer_runtime(
+    _fuzzer_asan_cc_binary,
+    "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
+)
 
 profile_cc_binary, _profile_cc_binary_internal = with_cfg(cc_binary).set(
     Label("@llvm//config:profile"),

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -357,6 +357,13 @@ copy_to_resource_directory(
             "//runtimes/compiler-rt:clang_rt.profile.static": "libclang_rt.profile_osx",
         },
         "//conditions:default": {},
+    }) | select({
+        "//config:fuzzer_enabled": {
+            "//runtimes/compiler-rt:clang_rt.fuzzer.static": "libclang_rt.fuzzer_osx",
+            "//runtimes/compiler-rt:clang_rt.fuzzer_no_main.static": "libclang_rt.fuzzer_no_main_osx",
+            "//runtimes/compiler-rt:clang_rt.fuzzer_interceptors.static": "libclang_rt.fuzzer_interceptors_osx",
+        },
+        "//conditions:default": {},
     }),
     target_compatible_with = ["@platforms//os:macos"],
     target_triple = "darwin",


### PR DESCRIPTION
Add the libFuzzer runtimes (`libclang_rt.fuzzer_osx.a`, `fuzzer_no_main_osx`, `fuzzer_interceptors_osx`) to the Darwin resource directory, so `-fsanitize=fuzzer` links on macOS instead of failing with a missing archive and undefined main.
Enables the three existing e2e/rules_cc fuzzer tests on macOS.