### PR TITLE
Support freestanding AArch64

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -651,6 +651,11 @@ cc_library(
             "COMPILER_RT_HAS_FLOAT16",
         ],
         "//conditions:default": [],
+    }) + selects.with_or({
+        (
+            "@llvm//platforms/config:none_aarch64",
+        ): ["ENABLE_BAREMETAL_AARCH64_FMV"],
+        "//conditions:default": [],
     }),
     textual_hdrs = [
         "lib/builtins/fp_add_impl.inc",
@@ -699,6 +704,9 @@ cc_library(
         ],
         "@llvm//platforms/config:windows_aarch64": [
             "lib/builtins/cpu_model/aarch64/fmv/windows.inc",
+        ],
+        "@llvm//platforms/config:none_aarch64": [
+            "lib/builtins/cpu_model/aarch64/fmv/baremetal.inc",
         ],
         "//conditions:default": [],
     }),

--- a/platforms/common.bzl
+++ b/platforms/common.bzl
@@ -16,6 +16,7 @@ SUPPORTED_TARGETS = [
     ("linux", "armv7"),
     ("windows", "x86_64"),
     ("windows", "aarch64"),
+    ("none", "aarch64"),
     ("none", "bpfeb"),
     ("none", "bpfel"),
     ("none", "wasm32"),

--- a/runtimes/copy_to_resource_directory.bzl
+++ b/runtimes/copy_to_resource_directory.bzl
@@ -21,6 +21,7 @@ TRIPLE_SELECT_DICT = {
     "@llvm//platforms/config:linux_armv7_musl": "armv7-unknown-linux-musleabihf",
     "@llvm//platforms/config:macos_x86_64": "darwin",
     "@llvm//platforms/config:macos_aarch64": "darwin",
+    "@llvm//platforms/config:none_aarch64": "aarch64-unknown-none-elf",
     "@llvm//platforms/config:none_bpfeb": "bpfeb-unknown-none",
     "@llvm//platforms/config:none_bpfel": "bpfel-unknown-none",
     "@llvm//platforms/config:none_wasm32": "wasm32-unknown-unknown",

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -324,13 +324,20 @@ cc_args_list(
 )
 
 cc_args_list(
+    name = "freestanding_toolchain_args",
+    args = [
+        "//toolchain/args:cxxstdlib_headers_include_search_paths",
+    ],
+)
+
+cc_args_list(
     name = "platform_specific_args",
     args = select({
         # Platform specific flags.
         "@platforms//os:macos": [":macos_toolchain_args"],
         "@platforms//os:linux": [":linux_toolchain_args"],
         "@platforms//os:windows": [":windows_toolchain_args"],
-        "@platforms//os:none": [],
+        "@platforms//os:none": [":freestanding_toolchain_args"],
         "//conditions:default": [],
     }),
 )

--- a/toolchain/args/llvm_target_triple.bzl
+++ b/toolchain/args/llvm_target_triple.bzl
@@ -14,6 +14,7 @@ LLVM_TARGET_TRIPLE = select({
     "@llvm//platforms/config:linux_armv7_musl": ["armv7-linux-musleabihf"],
     "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],
     "@llvm//platforms/config:macos_aarch64": ["aarch64-apple-darwin"],
+    "@llvm//platforms/config:none_aarch64": ["aarch64-unknown-none-elf"],
     "@llvm//platforms/config:none_bpfeb": ["bpfeb"],
     "@llvm//platforms/config:none_bpfel": ["bpfel"],
     "@llvm//platforms/config:none_wasm32": ["wasm32-unknown-unknown"],


### PR DESCRIPTION
This adds support for the `aarch64-unknown-none-elf` target triple.

My experimental Fuchsia fork's  zircon kernel expects the the libcxx headers to be provided on top of the ktl headers, but it only ever uses the freestanding headers.

https://github.com/hermeticbuild/hermetic-llvm/issues/434 would also be helpful here.