### PR TITLE
Make Windows ABI authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,15 @@ constraint to the target platform.
 
 Windows is currently supported via MinGW-w64. UCRT is used by default; MSVCRT
 can be selected by adding the `@llvm//constraints/windows/crt:msvcrt` constraint
-to the target platform. Native MSVC targets are not yet supported.
+to the target platform. This CRT constraint selects a MinGW-w64 runtime flavor;
+it does not select the MSVC target ABI.
+
+Repository-provided Windows platforms use the
+`@llvm//constraints/windows/abi:gnu` ABI. User-defined Windows platforms that
+omit this toolchain-specific constraint retain the same MinGW behavior. The
+`gnullvm` value is accepted for Rust compatibility and uses Clang's GNU Windows
+target environment. Native `@llvm//constraints/windows/abi:msvc` targets are not
+yet supported and intentionally have no compatible C/C++ toolchain.
 
 ### macOS notes
 

--- a/constraints/windows/abi/BUILD.bazel
+++ b/constraints/windows/abi/BUILD.bazel
@@ -1,20 +1,22 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load(":abis.bzl", "WINDOWS_ABIS", "WINDOWS_DEFAULT_ABI")
+
 package(default_visibility = ["//visibility:public"])
 
 constraint_setting(
     name = "abi",
+    default_constraint_value = WINDOWS_DEFAULT_ABI,
 )
 
-constraint_value(
-    name = "gnu",
-    constraint_setting = ":abi",
-)
+[
+    constraint_value(
+        name = abi,
+        constraint_setting = ":abi",
+    )
+    for abi in WINDOWS_ABIS
+]
 
-constraint_value(
-    name = "gnullvm",
-    constraint_setting = ":abi",
-)
-
-constraint_value(
-    name = "msvc",
-    constraint_setting = ":abi",
+bzl_library(
+    name = "abis",
+    srcs = ["abis.bzl"],
 )

--- a/constraints/windows/abi/abis.bzl
+++ b/constraints/windows/abi/abis.bzl
@@ -21,6 +21,11 @@ WINDOWS_TARGET_TRIPLES = {
     ("aarch64", "msvc"): "aarch64-pc-windows-msvc",
 }
 
+WINDOWS_TARGET_TRIPLES_BY_CONFIG = {
+    "@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi): target_triple
+    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items()
+}
+
 # The existing Windows C/C++ toolchain is configured with MinGW headers,
 # runtimes, GNU driver syntax, and GNU-mode LLD. Rust's gnullvm target uses the
 # same LLVM *-windows-gnu target environment, so it is compatible too.

--- a/constraints/windows/abi/abis.bzl
+++ b/constraints/windows/abi/abis.bzl
@@ -1,0 +1,31 @@
+WINDOWS_ABIS = [
+    "unconstrained",
+    "gnu",
+    "gnullvm",
+    "msvc",
+]
+
+# Constraint defaults apply to every OS. Consumers of this setting must also
+# require @platforms//os:windows before interpreting one of these values.
+WINDOWS_DEFAULT_ABI = "unconstrained"
+WINDOWS_GENERIC_PLATFORM_ABI = "gnu"
+
+WINDOWS_TARGET_TRIPLES = {
+    ("x86_64", "unconstrained"): "x86_64-w64-windows-gnu",
+    ("x86_64", "gnu"): "x86_64-w64-windows-gnu",
+    ("x86_64", "gnullvm"): "x86_64-w64-windows-gnu",
+    ("x86_64", "msvc"): "x86_64-pc-windows-msvc",
+    ("aarch64", "unconstrained"): "aarch64-w64-windows-gnu",
+    ("aarch64", "gnu"): "aarch64-w64-windows-gnu",
+    ("aarch64", "gnullvm"): "aarch64-w64-windows-gnu",
+    ("aarch64", "msvc"): "aarch64-pc-windows-msvc",
+}
+
+# The existing Windows C/C++ toolchain is configured with MinGW headers,
+# runtimes, GNU driver syntax, and GNU-mode LLD. Rust's gnullvm target uses the
+# same LLVM *-windows-gnu target environment, so it is compatible too.
+WINDOWS_MINGW_COMPATIBLE_ABIS = [
+    "unconstrained",
+    "gnu",
+    "gnullvm",
+]

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -11,6 +11,7 @@ bzl_library(
         ":common",
         "//constraints/cxxstdlib:cxxstdlib_versions",
         "//constraints/libc:libc_versions",
+        "//constraints/windows/abi:abis",
     ],
 )
 

--- a/platforms/common.bzl
+++ b/platforms/common.bzl
@@ -31,6 +31,8 @@ SUPPORTED_EXECS = [
     ("windows", "aarch64"),
 ]
 
+WINDOWS_TARGETS = [target for target in SUPPORTED_TARGETS if target[0] == "windows"]
+
 LIBC_SUPPORTED_TARGETS = [
     ("linux", "x86_64"),
     ("linux", "aarch64"),

--- a/platforms/config/BUILD.bazel
+++ b/platforms/config/BUILD.bazel
@@ -9,6 +9,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//constraints/libc:libc_versions",
+        "//constraints/windows/abi:abis",
         "//platforms:common",
         "//toolchain:bootstrap_stages",
         "@bazel_skylib//lib:selects",

--- a/platforms/config/declare_config_settings.bzl
+++ b/platforms/config/declare_config_settings.bzl
@@ -1,6 +1,7 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//constraints/libc:libc_versions.bzl", "GLIBCS", "LIBCS")
-load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS", "SUPPORTED_TARGETS")
+load("//constraints/windows/abi:abis.bzl", "WINDOWS_ABIS", "WINDOWS_MINGW_COMPATIBLE_ABIS")
+load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS", "SUPPORTED_TARGETS", "WINDOWS_TARGETS")
 load("//toolchain:bootstrap_stages.bzl", "BOOTSTRAP_STAGES")
 
 def declare_config_settings():
@@ -28,6 +29,7 @@ def declare_config_settings():
             )
 
     declare_config_settings_libc_aware()
+    declare_config_settings_windows_abi_aware()
 
 def declare_config_settings_libc_aware():
     for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS:
@@ -71,3 +73,25 @@ def declare_config_settings_libc_aware():
         ],
         visibility = ["//visibility:public"],
     )
+
+def declare_config_settings_windows_abi_aware():
+    for target_os, target_cpu in WINDOWS_TARGETS:
+        for abi in WINDOWS_ABIS:
+            native.config_setting(
+                name = "{}_{}_{}".format(target_os, target_cpu, abi),
+                constraint_values = [
+                    "@platforms//cpu:" + target_cpu,
+                    "@platforms//os:" + target_os,
+                    "//constraints/windows/abi:" + abi,
+                ],
+                visibility = ["//visibility:public"],
+            )
+
+        selects.config_setting_group(
+            name = "{}_{}_mingw_compatible".format(target_os, target_cpu),
+            match_any = [
+                "{}_{}_{}".format(target_os, target_cpu, abi)
+                for abi in WINDOWS_MINGW_COMPATIBLE_ABIS
+            ],
+            visibility = ["//visibility:public"],
+        )

--- a/platforms/declare_platforms.bzl
+++ b/platforms/declare_platforms.bzl
@@ -1,5 +1,6 @@
 load("//constraints/cxxstdlib:cxxstdlib_versions.bzl", "DEFAULT_CXXSTDLIB")
 load("//constraints/libc:libc_versions.bzl", "LIBCS", "default_libc")
+load("//constraints/windows/abi:abis.bzl", "WINDOWS_GENERIC_PLATFORM_ABI")
 load("//platforms:common.bzl", "ARCH_ALIASES", "LIBC_SUPPORTED_TARGETS", "SUPPORTED_TARGETS")
 
 def declare_platforms():
@@ -22,6 +23,13 @@ def declare_platforms():
             # Users can still create their own platforms without a libc
             # constraint if they want to.
             constraints.append("//constraints/libc:{}".format(default_libc(target_os, target_cpu)))
+
+        if target_os == "windows":
+            # Repository-owned Windows platforms state their existing GNU ABI
+            # contract explicitly. The constraint default remains
+            # unconstrained for downstream platforms that do not know about
+            # this toolchain-specific dimension.
+            constraints.append("//constraints/windows/abi:" + WINDOWS_GENERIC_PLATFORM_ABI)
 
         native.platform(
             name = "{}_{}".format(target_os, target_cpu),

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -384,6 +384,7 @@ bzl_library(
     srcs = ["copy_to_resource_directory.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//constraints/windows/abi:abis",
         "@bazel_lib//lib:copy_file",
         "@bazel_lib//lib:copy_to_directory",
     ],

--- a/runtimes/copy_to_resource_directory.bzl
+++ b/runtimes/copy_to_resource_directory.bzl
@@ -1,32 +1,39 @@
 load("@bazel_lib//lib:copy_file.bzl", "COPY_FILE_TOOLCHAINS", "copy_file_action")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory_bin_action")
+load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES")
 
 # echo 'int main() {}' | bazel run //tools:clang -- -x c - -fuse-ld=lld -v --rtlib=compiler-rt -### --target=<triple>
-TRIPLE_SELECT_DICT = {
-    "@llvm//platforms/config:linux_x86_64": "x86_64-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_aarch64": "aarch64-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_riscv64": "riscv64-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_s390x": "s390x-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_armv7": "armv7-unknown-linux-gnueabihf",
-    "@llvm//platforms/config:linux_x86_64_gnu": "x86_64-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_aarch64_gnu": "aarch64-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_riscv64_gnu": "riscv64-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_s390x_gnu": "s390x-unknown-linux-gnu",
-    "@llvm//platforms/config:linux_armv7_gnu": "armv7-unknown-linux-gnueabihf",
-    "@llvm//platforms/config:linux_x86_64_musl": "x86_64-unknown-linux-musl",
-    "@llvm//platforms/config:linux_aarch64_musl": "aarch64-unknown-linux-musl",
-    "@llvm//platforms/config:linux_riscv64_musl": "riscv64-unknown-linux-musl",
-    "@llvm//platforms/config:linux_s390x_musl": "s390x-unknown-linux-musl",
-    "@llvm//platforms/config:linux_armv7_musl": "armv7-unknown-linux-musleabihf",
-    "@llvm//platforms/config:macos_x86_64": "darwin",
-    "@llvm//platforms/config:macos_aarch64": "darwin",
-    "@llvm//platforms/config:windows_x86_64": "x86_64-w64-windows-gnu",
-    "@llvm//platforms/config:windows_aarch64": "aarch64-w64-windows-gnu",
-    "@llvm//platforms/config:none_bpfeb": "bpfeb-unknown-none",
-    "@llvm//platforms/config:none_bpfel": "bpfel-unknown-none",
-    "@llvm//platforms/config:none_wasm32": "wasm32-unknown-unknown",
-    "@llvm//platforms/config:none_wasm64": "wasm64-unknown-unknown",
-}
+def _triple_select_dict():
+    triples = {
+        "@llvm//platforms/config:linux_x86_64": "x86_64-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_aarch64": "aarch64-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_riscv64": "riscv64-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_s390x": "s390x-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_armv7": "armv7-unknown-linux-gnueabihf",
+        "@llvm//platforms/config:linux_x86_64_gnu": "x86_64-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_aarch64_gnu": "aarch64-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_riscv64_gnu": "riscv64-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_s390x_gnu": "s390x-unknown-linux-gnu",
+        "@llvm//platforms/config:linux_armv7_gnu": "armv7-unknown-linux-gnueabihf",
+        "@llvm//platforms/config:linux_x86_64_musl": "x86_64-unknown-linux-musl",
+        "@llvm//platforms/config:linux_aarch64_musl": "aarch64-unknown-linux-musl",
+        "@llvm//platforms/config:linux_riscv64_musl": "riscv64-unknown-linux-musl",
+        "@llvm//platforms/config:linux_s390x_musl": "s390x-unknown-linux-musl",
+        "@llvm//platforms/config:linux_armv7_musl": "armv7-unknown-linux-musleabihf",
+        "@llvm//platforms/config:macos_x86_64": "darwin",
+        "@llvm//platforms/config:macos_aarch64": "darwin",
+        "@llvm//platforms/config:none_bpfeb": "bpfeb-unknown-none",
+        "@llvm//platforms/config:none_bpfel": "bpfel-unknown-none",
+        "@llvm//platforms/config:none_wasm32": "wasm32-unknown-unknown",
+        "@llvm//platforms/config:none_wasm64": "wasm64-unknown-unknown",
+    }
+
+    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items():
+        triples["@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi)] = target_triple
+
+    return triples
+
+TRIPLE_SELECT_DICT = _triple_select_dict()
 
 def _copy_to_resource_directory_rule_impl(ctx):
     # Private staging folder inside the output-dir layout before we rewrite prefixes.

--- a/runtimes/copy_to_resource_directory.bzl
+++ b/runtimes/copy_to_resource_directory.bzl
@@ -1,6 +1,6 @@
 load("@bazel_lib//lib:copy_file.bzl", "COPY_FILE_TOOLCHAINS", "copy_file_action")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory_bin_action")
-load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES")
+load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES_BY_CONFIG")
 
 # echo 'int main() {}' | bazel run //tools:clang -- -x c - -fuse-ld=lld -v --rtlib=compiler-rt -### --target=<triple>
 TRIPLE_SELECT_DICT = {
@@ -25,10 +25,7 @@ TRIPLE_SELECT_DICT = {
     "@llvm//platforms/config:none_bpfel": "bpfel-unknown-none",
     "@llvm//platforms/config:none_wasm32": "wasm32-unknown-unknown",
     "@llvm//platforms/config:none_wasm64": "wasm64-unknown-unknown",
-} | {
-    "@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi): target_triple
-    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items()
-}
+} | WINDOWS_TARGET_TRIPLES_BY_CONFIG
 
 def _copy_to_resource_directory_rule_impl(ctx):
     # Private staging folder inside the output-dir layout before we rewrite prefixes.

--- a/runtimes/copy_to_resource_directory.bzl
+++ b/runtimes/copy_to_resource_directory.bzl
@@ -3,37 +3,32 @@ load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory_bin_action")
 load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES")
 
 # echo 'int main() {}' | bazel run //tools:clang -- -x c - -fuse-ld=lld -v --rtlib=compiler-rt -### --target=<triple>
-def _triple_select_dict():
-    triples = {
-        "@llvm//platforms/config:linux_x86_64": "x86_64-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_aarch64": "aarch64-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_riscv64": "riscv64-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_s390x": "s390x-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_armv7": "armv7-unknown-linux-gnueabihf",
-        "@llvm//platforms/config:linux_x86_64_gnu": "x86_64-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_aarch64_gnu": "aarch64-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_riscv64_gnu": "riscv64-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_s390x_gnu": "s390x-unknown-linux-gnu",
-        "@llvm//platforms/config:linux_armv7_gnu": "armv7-unknown-linux-gnueabihf",
-        "@llvm//platforms/config:linux_x86_64_musl": "x86_64-unknown-linux-musl",
-        "@llvm//platforms/config:linux_aarch64_musl": "aarch64-unknown-linux-musl",
-        "@llvm//platforms/config:linux_riscv64_musl": "riscv64-unknown-linux-musl",
-        "@llvm//platforms/config:linux_s390x_musl": "s390x-unknown-linux-musl",
-        "@llvm//platforms/config:linux_armv7_musl": "armv7-unknown-linux-musleabihf",
-        "@llvm//platforms/config:macos_x86_64": "darwin",
-        "@llvm//platforms/config:macos_aarch64": "darwin",
-        "@llvm//platforms/config:none_bpfeb": "bpfeb-unknown-none",
-        "@llvm//platforms/config:none_bpfel": "bpfel-unknown-none",
-        "@llvm//platforms/config:none_wasm32": "wasm32-unknown-unknown",
-        "@llvm//platforms/config:none_wasm64": "wasm64-unknown-unknown",
-    }
-
-    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items():
-        triples["@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi)] = target_triple
-
-    return triples
-
-TRIPLE_SELECT_DICT = _triple_select_dict()
+TRIPLE_SELECT_DICT = {
+    "@llvm//platforms/config:linux_x86_64": "x86_64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_aarch64": "aarch64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_riscv64": "riscv64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_s390x": "s390x-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_armv7": "armv7-unknown-linux-gnueabihf",
+    "@llvm//platforms/config:linux_x86_64_gnu": "x86_64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_aarch64_gnu": "aarch64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_riscv64_gnu": "riscv64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_s390x_gnu": "s390x-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_armv7_gnu": "armv7-unknown-linux-gnueabihf",
+    "@llvm//platforms/config:linux_x86_64_musl": "x86_64-unknown-linux-musl",
+    "@llvm//platforms/config:linux_aarch64_musl": "aarch64-unknown-linux-musl",
+    "@llvm//platforms/config:linux_riscv64_musl": "riscv64-unknown-linux-musl",
+    "@llvm//platforms/config:linux_s390x_musl": "s390x-unknown-linux-musl",
+    "@llvm//platforms/config:linux_armv7_musl": "armv7-unknown-linux-musleabihf",
+    "@llvm//platforms/config:macos_x86_64": "darwin",
+    "@llvm//platforms/config:macos_aarch64": "darwin",
+    "@llvm//platforms/config:none_bpfeb": "bpfeb-unknown-none",
+    "@llvm//platforms/config:none_bpfel": "bpfel-unknown-none",
+    "@llvm//platforms/config:none_wasm32": "wasm32-unknown-unknown",
+    "@llvm//platforms/config:none_wasm64": "wasm64-unknown-unknown",
+} | {
+    "@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi): target_triple
+    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items()
+}
 
 def _copy_to_resource_directory_rule_impl(ctx):
     # Private staging folder inside the output-dir layout before we rewrite prefixes.

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -978,4 +978,5 @@ cc_args(
 bzl_library(
     name = "llvm_target_triple",
     srcs = ["llvm_target_triple.bzl"],
+    deps = ["//constraints/windows/abi:abis"],
 )

--- a/toolchain/args/llvm_target_triple.bzl
+++ b/toolchain/args/llvm_target_triple.bzl
@@ -1,29 +1,24 @@
-load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES")
+load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES_BY_CONFIG")
 
-def _llvm_target_triples():
-    triples = {
-        # TODO: Generate this automatically.
-        "@llvm//platforms/config:linux_x86_64_gnu": ["x86_64-linux-gnu"],
-        "@llvm//platforms/config:linux_aarch64_gnu": ["aarch64-linux-gnu"],
-        "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
-        "@llvm//platforms/config:linux_s390x_gnu": ["s390x-linux-gnu"],
-        "@llvm//platforms/config:linux_armv7_gnu": ["armv7-linux-gnueabihf"],
-        "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
-        "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
-        "@llvm//platforms/config:linux_riscv64_musl": ["riscv64-linux-musl"],
-        "@llvm//platforms/config:linux_s390x_musl": ["s390x-linux-musl"],
-        "@llvm//platforms/config:linux_armv7_musl": ["armv7-linux-musleabihf"],
-        "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],
-        "@llvm//platforms/config:macos_aarch64": ["aarch64-apple-darwin"],
-        "@llvm//platforms/config:none_bpfeb": ["bpfeb"],
-        "@llvm//platforms/config:none_bpfel": ["bpfel"],
-        "@llvm//platforms/config:none_wasm32": ["wasm32-unknown-unknown"],
-        "@llvm//platforms/config:none_wasm64": ["wasm64-unknown-unknown"],
-    }
-
-    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items():
-        triples["@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi)] = [target_triple]
-
-    return triples
-
-LLVM_TARGET_TRIPLE = select(_llvm_target_triples(), no_match_error = "Unsupported platform")
+LLVM_TARGET_TRIPLE = select({
+    # TODO: Generate this automatically.
+    "@llvm//platforms/config:linux_x86_64_gnu": ["x86_64-linux-gnu"],
+    "@llvm//platforms/config:linux_aarch64_gnu": ["aarch64-linux-gnu"],
+    "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
+    "@llvm//platforms/config:linux_s390x_gnu": ["s390x-linux-gnu"],
+    "@llvm//platforms/config:linux_armv7_gnu": ["armv7-linux-gnueabihf"],
+    "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
+    "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
+    "@llvm//platforms/config:linux_riscv64_musl": ["riscv64-linux-musl"],
+    "@llvm//platforms/config:linux_s390x_musl": ["s390x-linux-musl"],
+    "@llvm//platforms/config:linux_armv7_musl": ["armv7-linux-musleabihf"],
+    "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],
+    "@llvm//platforms/config:macos_aarch64": ["aarch64-apple-darwin"],
+    "@llvm//platforms/config:none_bpfeb": ["bpfeb"],
+    "@llvm//platforms/config:none_bpfel": ["bpfel"],
+    "@llvm//platforms/config:none_wasm32": ["wasm32-unknown-unknown"],
+    "@llvm//platforms/config:none_wasm64": ["wasm64-unknown-unknown"],
+} | {
+    target_config: [target_triple]
+    for target_config, target_triple in WINDOWS_TARGET_TRIPLES_BY_CONFIG.items()
+}, no_match_error = "Unsupported platform")

--- a/toolchain/args/llvm_target_triple.bzl
+++ b/toolchain/args/llvm_target_triple.bzl
@@ -1,21 +1,29 @@
-LLVM_TARGET_TRIPLE = select({
-    #TODO: Generate this automatically
-    "@llvm//platforms/config:linux_x86_64_gnu": ["x86_64-linux-gnu"],
-    "@llvm//platforms/config:linux_aarch64_gnu": ["aarch64-linux-gnu"],
-    "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
-    "@llvm//platforms/config:linux_s390x_gnu": ["s390x-linux-gnu"],
-    "@llvm//platforms/config:linux_armv7_gnu": ["armv7-linux-gnueabihf"],
-    "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
-    "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
-    "@llvm//platforms/config:linux_riscv64_musl": ["riscv64-linux-musl"],
-    "@llvm//platforms/config:linux_s390x_musl": ["s390x-linux-musl"],
-    "@llvm//platforms/config:linux_armv7_musl": ["armv7-linux-musleabihf"],
-    "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],
-    "@llvm//platforms/config:macos_aarch64": ["aarch64-apple-darwin"],
-    "@llvm//platforms/config:windows_x86_64": ["x86_64-w64-windows-gnu"],
-    "@llvm//platforms/config:windows_aarch64": ["aarch64-w64-windows-gnu"],
-    "@llvm//platforms/config:none_bpfeb": ["bpfeb"],
-    "@llvm//platforms/config:none_bpfel": ["bpfel"],
-    "@llvm//platforms/config:none_wasm32": ["wasm32-unknown-unknown"],
-    "@llvm//platforms/config:none_wasm64": ["wasm64-unknown-unknown"],
-}, no_match_error = "Unsupported platform")
+load("//constraints/windows/abi:abis.bzl", "WINDOWS_TARGET_TRIPLES")
+
+def _llvm_target_triples():
+    triples = {
+        # TODO: Generate this automatically.
+        "@llvm//platforms/config:linux_x86_64_gnu": ["x86_64-linux-gnu"],
+        "@llvm//platforms/config:linux_aarch64_gnu": ["aarch64-linux-gnu"],
+        "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
+        "@llvm//platforms/config:linux_s390x_gnu": ["s390x-linux-gnu"],
+        "@llvm//platforms/config:linux_armv7_gnu": ["armv7-linux-gnueabihf"],
+        "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
+        "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
+        "@llvm//platforms/config:linux_riscv64_musl": ["riscv64-linux-musl"],
+        "@llvm//platforms/config:linux_s390x_musl": ["s390x-linux-musl"],
+        "@llvm//platforms/config:linux_armv7_musl": ["armv7-linux-musleabihf"],
+        "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],
+        "@llvm//platforms/config:macos_aarch64": ["aarch64-apple-darwin"],
+        "@llvm//platforms/config:none_bpfeb": ["bpfeb"],
+        "@llvm//platforms/config:none_bpfel": ["bpfel"],
+        "@llvm//platforms/config:none_wasm32": ["wasm32-unknown-unknown"],
+        "@llvm//platforms/config:none_wasm64": ["wasm64-unknown-unknown"],
+    }
+
+    for (target_cpu, target_abi), target_triple in WINDOWS_TARGET_TRIPLES.items():
+        triples["@llvm//platforms/config:windows_{}_{}".format(target_cpu, target_abi)] = [target_triple]
+
+    return triples
+
+LLVM_TARGET_TRIPLE = select(_llvm_target_triples(), no_match_error = "Unsupported platform")

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -427,6 +427,10 @@ def declare_toolchains(*, execs = None, targets = SUPPORTED_TARGETS):
             )
 
             for (target_os, target_cpu) in targets:
+                target_settings = [target_setting]
+                if target_os == "windows":
+                    target_settings.append("@llvm//platforms/config:windows_{}_mingw_compatible".format(target_cpu))
+
                 native.toolchain(
                     name = "%s_%s_%s_to_%s_%s" % (stage_name, exec_os, exec_cpu, target_os, target_cpu),
                     exec_compatible_with = [
@@ -437,9 +441,7 @@ def declare_toolchains(*, execs = None, targets = SUPPORTED_TARGETS):
                         "@platforms//cpu:" + target_cpu,
                         "@platforms//os:" + target_os,
                     ],
-                    target_settings = [
-                        target_setting,
-                    ],
+                    target_settings = target_settings,
                     toolchain = cc_toolchain_name,
                     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
                     visibility = ["//visibility:public"],

--- a/toolchain/declare_toolchains.bzl
+++ b/toolchain/declare_toolchains.bzl
@@ -25,6 +25,10 @@ def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
         )
 
         for (target_os, target_cpu) in targets:
+            target_settings = ["@llvm//toolchain:bootstrap_stage0_prebuilt_seed"]
+            if target_os == "windows":
+                target_settings.append("@llvm//platforms/config:windows_{}_mingw_compatible".format(target_cpu))
+
             native.toolchain(
                 name = "{}_{}_to_{}_{}".format(exec_os, exec_cpu, target_os, target_cpu),
                 exec_compatible_with = [
@@ -35,9 +39,7 @@ def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
                     "@platforms//cpu:{}".format(target_cpu),
                     "@platforms//os:{}".format(target_os),
                 ],
-                target_settings = [
-                    "@llvm//toolchain:bootstrap_stage0_prebuilt_seed",
-                ],
+                target_settings = target_settings,
                 toolchain = cc_toolchain_name,
                 toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
                 visibility = ["//visibility:public"],


### PR DESCRIPTION
This is one of many preparation parts of #187 (which I'll merge last).

@ArchangelX360 I'm happy to add you as co-author of all commits from all those even if I'm going to eventually merge #187 since it rains down from your work there.

I wanted to rename "abi" to "target_environment" since it's really what it is, and also rename "gnu" to "mingw" but I thought it'd be breaking too much downstream.

## Summary

- make the Windows ABI constraint authoritative for platform and target-triple selection
- preserve existing MinGW behavior for repository and ABI-omitting custom Windows platforms
- keep gnullvm as a Rust-facing compatibility spelling backed by Clang's Windows-GNU target
- reject explicit MSVC targets until an MSVC-capable C/C++ toolchain is registered
- derive compiler and runtime-resource Windows triples from one mapping

## Motivation

The previous Windows ABI constraint did not participate in toolchain resolution or target-triple routing. An explicit MSVC platform could therefore silently select the MinGW-configured toolchain. This change makes that boundary explicit without adding clang-cl, an MSVC SDK/runtime, linker, CRT, or STL support.

The global constraint default is neutral (`unconstrained`) so downstream platforms that do not know this repository-specific dimension keep working. Repository-provided Windows platforms state their existing GNU contract explicitly.

## Checks

- Bazel 8.7 and 9.2 focused analysis
- x86_64 and aarch64 GNU, omitted-ABI, and gnullvm compile actions use `*-w64-windows-gnu`
- explicit MSVC C/C++ toolchain resolution fails
- stage-one source-bootstrap Windows-GNU action inspected
- rules_rust and rules_rs Windows cross-build targets built for both architectures and linking paths
- runtime resource layouts inspected for GNU, gnullvm, omitted, and MSVC target families
- buildifier and structured autoreview
