### PR TITLE
Support dynamic libstdc++ with static project libs

### DIFF
--- a/3rd_party/gcc/extension/trampoline.BUILD.bazel
+++ b/3rd_party/gcc/extension/trampoline.BUILD.bazel
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 # hermetic-llvm.
 _SELECTED_FACADE_TARGETS = [
     "abi_headers_include_search_directory",
+    "build_headers",
     "headers_include_search_directory",
     "libstdcxx.shared",
     "libstdcxxfs",

--- a/3rd_party/gcc/libstdcxx/autoconf/cc_configure_probe.bzl
+++ b/3rd_party/gcc/libstdcxx/autoconf/cc_configure_probe.bzl
@@ -159,7 +159,9 @@ cmd=("$tool")
 for arg in "$@"; do
     case "$arg" in
         "$source_placeholder")
-            cmd+=("${extra_flags[@]}")
+            if [ "${#extra_flags[@]}" -gt 0 ]; then
+                cmd+=("${extra_flags[@]}")
+            fi
             cmd+=("$source")
             ;;
         "$output_placeholder")
@@ -261,7 +263,9 @@ compile_cmd=("$compile_tool")
 for arg in "${compile_args[@]}"; do
     case "$arg" in
         "$source_placeholder")
-            compile_cmd+=("${compile_extra_flags[@]}")
+            if [ "${#compile_extra_flags[@]}" -gt 0 ]; then
+                compile_cmd+=("${compile_extra_flags[@]}")
+            fi
             compile_cmd+=("$source")
             ;;
         "$object_placeholder")
@@ -285,7 +289,9 @@ for arg in "$@"; do
     esac
 done
 link_cmd+=("$object")
-link_cmd+=("${link_extra_flags[@]}")
+if [ "${#link_extra_flags[@]}" -gt 0 ]; then
+    link_cmd+=("${link_extra_flags[@]}")
+fi
 
 if "${compile_cmd[@]}" >"$log" 2>&1 && "${link_cmd[@]}" >>"$log" 2>&1; then
     echo true > "$result"

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -859,7 +859,12 @@ cc_library(
     name = "libcxx_headers",
     deps = select({
         "@platforms//os:macos": [],
-        "@platforms//os:linux": [
+        "@llvm//runtimes/cxxstdlib:libstdcxx_linux": [
+            # do not sort: linux_libc_headers have to come after libstdcxx
+            "@gcc//:build_headers",
+            ":linux_libc_headers",
+        ],
+        "@llvm//runtimes/cxxstdlib:libcxx_linux": [
             # do not sort: linux_libc_headers have to come after libcxx
             "@llvm-project//libcxx:headers",
             "@llvm-project//libcxxabi:headers",
@@ -872,6 +877,53 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+)
+
+cc_library(
+    name = "gcc_s_builtins",
+    srcs = [
+        "lib/builtins/addtf3.c",
+        "lib/builtins/comparetf2.c",
+        "lib/builtins/divtf3.c",
+        "lib/builtins/extendsftf2.c",
+        "lib/builtins/floatditf.c",
+        "lib/builtins/floatsitf.c",
+        "lib/builtins/floatunditf.c",
+        "lib/builtins/mulsc3.c",
+        "lib/builtins/multf3.c",
+        "lib/builtins/popcountdi2.c",
+        "lib/builtins/subtf3.c",
+        "lib/builtins/trunctfdf2.c",
+        "lib/builtins/trunctfsf2.c",
+        "lib/builtins/udivmodti4.c",
+        "lib/builtins/udivti3.c",
+    ] + select({
+        "@platforms//cpu:aarch64": ["lib/builtins/aarch64/fp_mode.c"],
+        "@platforms//cpu:x86_64": ["lib/builtins/i386/fp_mode.c"],
+        "//conditions:default": ["lib/builtins/fp_mode.c"],
+    }),
+    hdrs = [
+        "lib/builtins/fp_extend.h",
+        "lib/builtins/fp_lib.h",
+        "lib/builtins/fp_mode.h",
+        "lib/builtins/fp_trunc.h",
+        "lib/builtins/int_endianness.h",
+        "lib/builtins/int_lib.h",
+        "lib/builtins/int_math.h",
+        "lib/builtins/int_types.h",
+        "lib/builtins/int_util.h",
+    ],
+    copts = ["-fvisibility=default"],
+    textual_hdrs = [
+        "lib/builtins/fp_add_impl.inc",
+        "lib/builtins/fp_compare_impl.inc",
+        "lib/builtins/fp_div_impl.inc",
+        "lib/builtins/fp_extend_impl.inc",
+        "lib/builtins/fp_mul_impl.inc",
+        "lib/builtins/fp_trunc_impl.inc",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":linux_libc_headers"],
 )
 
 ###

--- a/3rd_party/llvm-project/x.x/libunwind/BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libunwind/BUILD.bazel
@@ -1,1 +1,4 @@
-exports_files(["libunwind.BUILD.bazel"])
+exports_files([
+    "libgcc_s.version",
+    "libunwind.BUILD.bazel",
+])

--- a/3rd_party/llvm-project/x.x/libunwind/libgcc_s.version
+++ b/3rd_party/llvm-project/x.x/libunwind/libgcc_s.version
@@ -1,0 +1,56 @@
+GCC_3.0 {
+  global:
+    _Unwind_DeleteException;
+    _Unwind_Find_FDE;
+    _Unwind_ForcedUnwind;
+    _Unwind_GetDataRelBase;
+    _Unwind_GetGR;
+    _Unwind_GetIP;
+    _Unwind_GetLanguageSpecificData;
+    _Unwind_GetRegionStart;
+    _Unwind_GetTextRelBase;
+    _Unwind_RaiseException;
+    _Unwind_Resume;
+    _Unwind_SetGR;
+    _Unwind_SetIP;
+    __addtf3;
+    __divtf3;
+    __eqtf2;
+    __extendsftf2;
+    __floatditf;
+    __floatsitf;
+    __getf2;
+    __gttf2;
+    __letf2;
+    __lttf2;
+    __multf3;
+    __netf2;
+    __subtf3;
+    __trunctfdf2;
+    __trunctfsf2;
+    __udivmodti4;
+    __udivti3;
+  local:
+    *;
+};
+GCC_3.3 {
+  global:
+    _Unwind_Backtrace;
+    _Unwind_FindEnclosingFunction;
+    _Unwind_GetCFA;
+    _Unwind_Resume_or_Rethrow;
+} GCC_3.0;
+GCC_3.4 {
+  global: __popcountdi2;
+} GCC_3.3;
+GCC_4.0.0 {
+  global: __mulsc3;
+} GCC_3.4;
+GCC_4.2.0 {
+  global:
+    _Unwind_GetIPInfo;
+    __floatunditf;
+} GCC_4.0.0;
+GCC_4.5.0 {
+  global: __unordtf2;
+} GCC_4.2.0;

--- a/3rd_party/llvm-project/x.x/libunwind/libunwind.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libunwind/libunwind.BUILD.bazel
@@ -182,3 +182,20 @@ cc_runtime_stage1_shared_library(
         ":libunwind",
     ],
 )
+
+cc_runtime_stage1_shared_library(
+    name = "libgcc_s.shared",
+    additional_linker_inputs = [
+        "@llvm//3rd_party/llvm-project/x.x/libunwind:libgcc_s.version",
+    ],
+    shared_lib_name = "libgcc_s.so.1",
+    user_link_flags = [
+        "-Wl,-soname,libgcc_s.so.1",
+        "-Wl,--version-script,$(location @llvm//3rd_party/llvm-project/x.x/libunwind:libgcc_s.version)",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":libunwind",
+        "@llvm-project//compiler-rt:gcc_s_builtins",
+    ],
+)

--- a/README.md
+++ b/README.md
@@ -186,23 +186,10 @@ Then build with that platform:
 bazel build --platforms=//:linux_x86_64_gnu_2_28_libstdcxx_17_0_0 //:app
 ```
 
-libstdc++ is currently supported as a dynamic C++ runtime, so C++ binaries
-using it must set `linkstatic = False`:
-
-```starlark
-cc_binary(
-    name = "app",
-    srcs = ["main.cc"],
-    linkstatic = False,
-)
-```
-
-With Bazel's default dynamic mode, `cc_binary` defaults `linkstatic` to `True`,
-which selects the toolchain's static C++ runtime path. For libstdc++ that would
-make static libstdc++ the default, which is not what most Linux users expect,
-and this toolchain intentionally supports libstdc++ through the dynamic runtime
-path. `--dynamic_mode=off` also forces the static runtime path, even when
-`linkstatic = False`, so it cannot be combined with libstdc++ support.
+libstdc++ is linked dynamically independently of Bazel's `linkstatic` setting.
+This lets binaries retain the default static linking of their project libraries
+while using the system `libstdc++.so.6` and `libgcc_s.so.1` at runtime. Both
+ordinary `cc_binary` targets and targets with `linkstatic = False` are supported.
 
 At the moment, libstdc++ support is limited to Linux glibc targets. Additional
 targets can be added based on demand; musl + libstdc++ is feasible too, even if

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -158,6 +158,21 @@ cc_binary(
 )
 
 cc_binary(
+    name = "libstdcxx_main_default",
+    srcs = ["main.cc"],
+    target_compatible_with = select({
+        "@llvm//constraints/cxxstdlib:libstdcxx": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        "@llvm//constraints/libc:musl": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_binary(
     name = "libstdcxx_main_dynamic_with_linkopts",
     srcs = ["main.cc"],
     linkopts = [
@@ -255,6 +270,32 @@ platform_transition_filegroup(
 )
 
 platform_transition_filegroup(
+    name = "libstdcxx_main_default_linux_x86_64",
+    srcs = [":libstdcxx_main_default"],
+    target_compatible_with = _LIBSTDCXX_E2E_TARGET_COMPATIBLE_WITH,
+    target_platform = ":linux_x86_64_libstdcxx",
+)
+
+platform_transition_filegroup(
+    name = "libstdcxx_main_default_linux_aarch64",
+    srcs = [":libstdcxx_main_default"],
+    target_compatible_with = _LIBSTDCXX_E2E_TARGET_COMPATIBLE_WITH,
+    target_platform = ":linux_aarch64_libstdcxx",
+)
+
+platform_transition_filegroup(
+    name = "glibc_2_39_pthread_compat_stubs",
+    srcs = ["@llvm//runtimes/glibc:libpthread.s"],
+    target_platform = "@llvm//platforms:linux_x86_64_gnu.2.39",
+)
+
+platform_transition_filegroup(
+    name = "glibc_2_39_dl_compat_stubs",
+    srcs = ["@llvm//runtimes/glibc:libdl.s"],
+    target_platform = "@llvm//platforms:linux_x86_64_gnu.2.39",
+)
+
+platform_transition_filegroup(
     name = "libstdcxx_main_dynamic_with_linkopts_linux_x86_64",
     srcs = [":libstdcxx_main_dynamic_with_linkopts"],
     target_compatible_with = _LIBSTDCXX_E2E_TARGET_COMPATIBLE_WITH,
@@ -304,6 +345,49 @@ exec_test(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+)
+
+exec_test(
+    name = "libstdcxx_main_default_output_test",
+    srcs = ["libstdcxx_main_dynamic_output_test.sh"],
+    data = [":libstdcxx_main_default_linux_x86_64"],
+    env = {"BINARY": "$(rootpath :libstdcxx_main_default_linux_x86_64)"},
+    rule = sh_test,
+    target_compatible_with = select({
+        "@platforms//cpu:x86_64": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+exec_test(
+    name = "libstdcxx_main_default_aarch64_output_test",
+    srcs = ["libstdcxx_main_dynamic_output_test.sh"],
+    data = [":libstdcxx_main_default_linux_aarch64"],
+    env = {"BINARY": "$(rootpath :libstdcxx_main_default_linux_aarch64)"},
+    rule = sh_test,
+    target_compatible_with = select({
+        "@platforms//cpu:aarch64": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+sh_test(
+    name = "glibc_merged_libraries_compat_test",
+    srcs = ["glibc_merged_libraries_compat_test.sh"],
+    args = [
+        "$(rootpath :glibc_2_39_pthread_compat_stubs)",
+        "$(rootpath :glibc_2_39_dl_compat_stubs)",
+    ],
+    data = [
+        ":glibc_2_39_dl_compat_stubs",
+        ":glibc_2_39_pthread_compat_stubs",
+    ],
 )
 
 exec_test(

--- a/e2e/rules_cc/glibc_merged_libraries_compat_test.sh
+++ b/e2e/rules_cc/glibc_merged_libraries_compat_test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pthread_stubs="$1"
+dl_stubs="$2"
+
+if ! grep -q 'pthread_create@@GLIBC_' "$pthread_stubs"; then
+  echo "glibc 2.39 libpthread stubs do not export pthread_create" >&2
+  exit 1
+fi
+
+if ! grep -q 'dlopen@@GLIBC_' "$dl_stubs"; then
+  echo "glibc 2.39 libdl stubs do not export dlopen" >&2
+  exit 1
+fi

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -325,7 +325,9 @@ copy_to_resource_directory(
 # safestack, scudo, gwp_asan, cfi, nsan, rtsan, tysan) are intentionally absent.
 copy_to_resource_directory(
     name = "resource_directory_macos",
-    srcs = select({
+    srcs = {
+        "//runtimes/compiler-rt:clang_rt.builtins.static": "libclang_rt.osx",
+    } | select({
         "//config:asan_enabled": {
             # asan ships as a dylib on Darwin (no static standalone runtime);
             # asan_cxx is folded into the dylib. The asan_static archive carries

--- a/runtimes/cxxstdlib/BUILD.bazel
+++ b/runtimes/cxxstdlib/BUILD.bazel
@@ -26,6 +26,14 @@ selects.config_setting_group(
     ],
 )
 
+selects.config_setting_group(
+    name = "libstdcxx_linux_complete",
+    match_all = [
+        ":libstdcxx_linux",
+        "//toolchain:runtimes_all",
+    ],
+)
+
 # Recognize the Windows selection only to fail at the cxxstdlib routing
 # boundary. The MinGW source/header entries in the libstdc++ port are audit
 # parity with GCC, not supported runtime wiring yet.
@@ -64,17 +72,6 @@ alias(
     }),
 )
 
-alias(
-    name = "libstdcxx_dynamic_runtime_lib",
-    actual = "//runtimes/libstdcxx:libstdcxx_shared_soname",
-)
-
-genrule(
-    name = "libstdcxx_static_runtime_lib",
-    outs = ["unsupported/libstdc++.a"],
-    cmd = "echo 'libstdc++ is only supported as a dynamic C++ runtime; static libstdc++ is intentionally unsupported.' >&2; exit 1",
-)
-
 genrule(
     name = "libstdcxx_windows_unsupported",
     outs = ["unsupported/windows-libstdcxx"],
@@ -86,7 +83,7 @@ genrule(
 filegroup(
     name = "static_runtime_lib",
     srcs = select({
-        ":libstdcxx_linux": [":libstdcxx_static_runtime_lib"],
+        ":libstdcxx_linux": [],
         ":libstdcxx_windows": [":libstdcxx_windows_unsupported"],
         ":libcxx_linux": [
             "@llvm-project//libcxx:libcxx.static",
@@ -105,10 +102,7 @@ filegroup(
 filegroup(
     name = "dynamic_runtime_lib",
     srcs = select({
-        ":libstdcxx_linux": [
-            ":libstdcxx_dynamic_runtime_lib",
-            "//runtimes/libunwind:libunwind.shared",
-        ],
+        ":libstdcxx_linux": [],
         ":libstdcxx_windows": [":libstdcxx_windows_unsupported"],
         ":libcxx_linux": [
             "@llvm-project//libcxx:libcxx.shared",

--- a/runtimes/glibc/glibc_stubs_assembly_files.bzl
+++ b/runtimes/glibc/glibc_stubs_assembly_files.bzl
@@ -1,17 +1,14 @@
-def _glibc_stubs_impl(ctx):
-    target = ctx.attr.target
-
-    version_script = ctx.actions.declare_file("build/all.map")
-
+def _generate_glibc_stubs(ctx, target, directory):
+    version_script = ctx.actions.declare_file(directory + "/all.map")
     assembly_outputs = {
-        "c": ctx.actions.declare_file("build/c.s"),
-        "dl": ctx.actions.declare_file("build/dl.s"),
-        "ld": ctx.actions.declare_file("build/ld.s"),
-        "m": ctx.actions.declare_file("build/m.s"),
-        "pthread": ctx.actions.declare_file("build/pthread.s"),
-        "resolv": ctx.actions.declare_file("build/resolv.s"),
-        "rt": ctx.actions.declare_file("build/rt.s"),
-        "util": ctx.actions.declare_file("build/util.s"),
+        "c": ctx.actions.declare_file(directory + "/c.s"),
+        "dl": ctx.actions.declare_file(directory + "/dl.s"),
+        "ld": ctx.actions.declare_file(directory + "/ld.s"),
+        "m": ctx.actions.declare_file(directory + "/m.s"),
+        "pthread": ctx.actions.declare_file(directory + "/pthread.s"),
+        "resolv": ctx.actions.declare_file(directory + "/resolv.s"),
+        "rt": ctx.actions.declare_file(directory + "/rt.s"),
+        "util": ctx.actions.declare_file(directory + "/util.s"),
     }
     outputs = list(assembly_outputs.values()) + [version_script]
 
@@ -28,6 +25,20 @@ def _glibc_stubs_impl(ctx):
         arguments = [args],
         outputs = outputs,
     )
+
+    return version_script, assembly_outputs
+
+def _glibc_stubs_impl(ctx):
+    target = ctx.attr.target
+    version_script, assembly_outputs = _generate_glibc_stubs(ctx, target, "build")
+
+    prefix, major, minor = target.rsplit(".", 2)
+    if int(major) > 2 or (int(major) == 2 and int(minor) >= 34):
+        _, compatibility_outputs = _generate_glibc_stubs(ctx, prefix + ".2.33", "build/compat")
+        for library in ["dl", "pthread", "rt", "util"]:
+            assembly_outputs[library] = compatibility_outputs[library]
+
+    outputs = list(assembly_outputs.values()) + [version_script]
 
     output_groups = {
         lib + "_s": depset([output])

--- a/runtimes/libstdcxx/BUILD.bazel
+++ b/runtimes/libstdcxx/BUILD.bazel
@@ -35,10 +35,6 @@ copy_file(
 )
 
 stub_library(
-    name = "stdc++",
-)
-
-stub_library(
     name = "supc++",
 )
 
@@ -52,7 +48,7 @@ copy_file(
 copy_to_directory(
     name = "libstdcxx_library_search_directory",
     srcs = [
-        ":stdc++",
+        ":libstdcxx_shared_linker_name",
         ":stdc++fs",
         ":supc++",
     ],

--- a/runtimes/libunwind/BUILD.bazel
+++ b/runtimes/libunwind/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("//runtimes:defs.bzl", "stub_library")
 
@@ -23,6 +24,13 @@ stub_library(
     visibility = ["//visibility:public"],
 )
 
+copy_file(
+    name = "gcc_s_dynamic",
+    src = "@llvm-project//libunwind:libgcc_s.shared",
+    out = "libgcc_s.so",
+    allow_symlink = True,
+)
+
 config_setting(
     name = "stub_libgcc_s",
     flag_values = {
@@ -36,6 +44,9 @@ copy_to_directory(
         ":unwind",
     ] + select({
         ":stub_libgcc_s": [":gcc_s"],
+        "//conditions:default": [],
+    }) + select({
+        "//runtimes/cxxstdlib:libstdcxx_linux": [":gcc_s_dynamic"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -114,7 +114,15 @@ cc_args(
         # Since libunwind is linked statically, we need to link dl as well.
         "-ldl",
         "-Wl,--pop-state",
-    ],
+    ] + select({
+        "//runtimes/cxxstdlib:libstdcxx_linux_complete": [
+            "-Wl,--push-state,--as-needed,-Bdynamic",
+            "-lstdc++",
+            "-lgcc_s",
+            "-Wl,--pop-state",
+        ],
+        "//conditions:default": [],
+    }),
     data = [
         "//runtimes/glibc:glibc_library_search_directory",
     ],

--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -105,15 +105,5 @@ cc_args(
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
-    # -l: is not supported by lld64
-    args = [
-        "-lSystem",
-        "{libclang_rt.builtins.a}",
-    ],
-    data = [
-        "//runtimes/compiler-rt:clang_rt.builtins.static",
-    ],
-    format = {
-        "libclang_rt.builtins.a": "//runtimes/compiler-rt:clang_rt.builtins.static",
-    },
+    args = [],
 )


### PR DESCRIPTION
Bazel currently treats linkstatic as the C++ runtime selection, which\nmakes ordinary cc_binary targets fail on Linux libstdc++ platforms.\nKeep project libraries static while resolving libstdc++ and its GNU\nexception unwinder dynamically.\n\nRetain legacy pthread, dl, rt, and util symbols for newer glibc targets,\nand put Darwin compiler builtins in Clang's resource directory. Cover\ndefault libstdc++ links on x86_64 and aarch64 and the glibc 2.39\ncompatibility-symbol regression.