### PR TITLE
Reduce PR Bazel cache churn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
       # Pull requests restore dependency caches published by main. PR-scoped caches can
       # only be reused by reruns of the same PR, so they are not saved here.
       - name: Restore Bazel repository cache
+        if: matrix.folder != 'e2e/cross_compilation'
         id: bazel-repository-cache
         uses: actions/cache/restore@v4
         with:
@@ -61,10 +62,16 @@ jobs:
         working-directory: ${{ matrix.folder }}
         shell: bash
         run: |
+          repository_cache_flags=()
+          if [[ "${{ matrix.folder }}" == "e2e/cross_compilation" ]]; then
+            repository_cache_flags+=(--repository_cache= --repo_contents_cache=)
+          fi
+
           bazel \
             --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
             --bazelrc=.bazelrc \
             test \
+            "${repository_cache_flags[@]}" \
             --remote_header=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
             ${{ matrix.extra_flags }} \
             //...
@@ -78,6 +85,7 @@ jobs:
               --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
               --bazelrc=.bazelrc \
               build \
+              "${repository_cache_flags[@]}" \
               --remote_header=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
               --repo_env=BAZEL_MSVC_RUNTIME_VISUAL_STUDIO_EULA=1 \
               --repo_env=BAZEL_WINDOWS_SDK_EULA=1 \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,25 +42,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Cache build and external artifacts so that the next ci build is incremental.
-      # Because github action caches cannot be updated after a build, we need to
-      # store the contents of each build in a unique cache key, then fall back to loading
-      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
-      # the prefix to load the most recent cache for the branch on a cache miss. You
-      # should customize the contents of hashFiles to capture any bazel input sources,
-      # although this doesn't need to be perfect. If none of the input sources change
-      # then a cache hit will load an existing cache and bazel won't have to do any work.
-      # In the case of a cache miss, you want the fallback cache to contain most of the
-      # previously built artifacts to minimize build time. The more precise you are with
-      # hashFiles sources the less work bazel will have to do.
-      - name: Mount bazel caches
-        uses: actions/cache@v4
+      # Pull requests restore dependency caches published by main. PR-scoped caches can
+      # only be reused by reruns of the same PR, so they are not saved here.
+      - name: Restore Bazel repository cache
+        id: bazel-repository-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/bazel-repo
-          key: bazel-cache-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'MODULE.bazel') }}
+          key: bazel-repository-v2-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', format('{0}/MODULE.bazel', matrix.folder), format('{0}/MODULE.bazel.lock', matrix.folder)) }}
           restore-keys: |
-            bazel-cache-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}
+            bazel-repository-v2-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}-
+            bazel-cache-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}-
 
       - name: bazel test //...
         env:
@@ -99,6 +92,22 @@ jobs:
         working-directory: ${{ matrix.folder }}
         shell: bash
         run: ./coverage_lcov_test.sh --remote_header=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7
+
+      - name: Stop Bazel before saving repository cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.folder != 'e2e/cross_compilation' && steps.bazel-repository-cache.outputs.cache-hit != 'true'
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc shutdown
+
+      - name: Save Bazel repository cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.folder != 'e2e/cross_compilation' && steps.bazel-repository-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/bazel-repo
+          key: ${{ steps.bazel-repository-cache.outputs.cache-primary-key }}
 
   test_windows:
     strategy:
@@ -282,14 +291,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Mount bazel caches
-        uses: actions/cache@v4
+      - name: Restore Bazel repository cache
+        id: bazel-repository-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/bazel-repo
-          key: bazel-cache-tests-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'MODULE.bazel') }}
+          key: bazel-repository-v2-tests-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel-cache-tests-${{ matrix.os }}-${{ matrix.bazel_version }}
+            bazel-repository-v2-tests-${{ matrix.os }}-${{ matrix.bazel_version }}-
+            bazel-cache-tests-${{ matrix.os }}-${{ matrix.bazel_version }}-
 
       - name: bazel query kernel headers and test root targets
         env:
@@ -313,6 +324,21 @@ jobs:
             //tools/case_insensitive_vfs:cli_test \
             //tools/case_insensitive_vfs:test \
             //tools/def_file_generator:test
+
+      - name: Stop Bazel before saving repository cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.bazel-repository-cache.outputs.cache-hit != 'true'
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        shell: bash
+        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc shutdown
+
+      - name: Save Bazel repository cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.bazel-repository-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/bazel-repo
+          key: ${{ steps.bazel-repository-cache.outputs.cache-primary-key }}
 
   docs:
     runs-on: macos-15-intel


### PR DESCRIPTION
## Motivation

Linux CI archived up to 6.5 GB of Bazel repository state after cache misses. Pull-request caches are scoped to that PR merge ref, so the uploads only help reruns of the same PR. In run 33340179423, two cross-compilation post steps spent 11m33s archiving and then failed because the live repo contents cache changed during the read.

## Contract

Pull requests may consume dependency caches published by `main`, but must not publish PR-scoped caches. Only successful pushes to `main` refresh shared caches. Cross-compilation must use the cache mode with the best measured end-to-end time.

## Root cause

The combined `actions/cache` restore/save action implicitly saved on every successful cache miss. Its key hashed every BUILD and Starlark file, causing unrelated source changes to rotate every matrix cache. The save also archived a live Bazel repo contents cache while Bazel remained running.

## Change

- split restore and save into explicit actions
- save only on pushes to `main`
- shut Bazel down before an allowed save
- key caches from module manifests and lockfiles
- retain existing cache prefixes as migration fallbacks
- skip GitHub cache restore/save for cross-compilation and disable its Bazel repository/contents caches

## Benchmark follow-up

[Run 33372776839](https://github.com/hermeticbuild/hermetic-llvm/actions/runs/33372776839) seeded stable caches after `bazel shutdown`, then measured three fresh runners for each mode and Bazel version.

| Bazel | Mode | Median restore | Median Bazel | Median total |
|---|---:|---:|---:|---:|
| 8.x | none | 0s | 425s | 435s |
| 8.x | downloads-only | 6s | 415s | 432s |
| 8.x | full contents | 113s | 361s | 478s |
| last_rc | none | 0s | 423s | 429s |
| last_rc | downloads-only | 21s | 404s | 423s |
| last_rc | full contents | 253s | 268s | 507s |

Downloads-only changed median total time by just 3–6 seconds, within observed variance. Full contents regressed median total time by 43–78 seconds. Full-cache saves took 344–389 seconds and produced 3.78–6.44 GB entries; downloads-only saves took 5–13 seconds and produced 1.04–2.38 GB entries.

The original PR commit passed the complete CI matrix. YAML parsing, shell-array behavior, and diff checks pass after the benchmark-driven update.