### PR TITLE
Declare shared ThinLTO backend features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
           repository_cache_flags=()
           if [[ "${{ matrix.folder }}" == "e2e/cross_compilation" ]]; then
             repository_cache_flags+=(--repository_cache= --repo_contents_cache=)
+            repository_cache_flags+=(--jobs=100)
           fi
 
           bazel \
@@ -154,8 +155,23 @@ jobs:
             --repository_cache= \
             --repo_contents_cache= \
             --jobs=100 \
+            --test_tag_filters=-thin_lto_feature \
             $EXTRA_ARGS \
             //...
+
+          if [[ "${{ matrix.folder }}" == "e2e/rules_cc" ]]; then
+            bazel \
+              --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
+              --bazelrc=.bazelrc \
+              --noexperimental_remote_repo_contents_cache \
+              build \
+              --repository_cache= \
+              --repo_contents_cache= \
+              --jobs=100 \
+              //:thin_lto_shared_backends_disabled_test \
+              //:thin_lto_linkstatic_tests_shared_backends_test \
+              //:thin_lto_all_linkstatic_shared_backends_test
+          fi
 
   # macOS: smoke build (//:main_default) plus the supported sanitizer e2e tests.
   test_macos:

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -39,6 +39,7 @@ load(
 )
 load(":bazel_version.bzl", "validate_static_library_compatible")
 load(":musl_header_generation_tests.bzl", "musl_header_generation_tests")
+load(":thin_lto_features_test.bzl", "thin_lto_features_test")
 load(":windows_msvc_artifacts.bzl", "windows_msvc_artifacts")
 load(":windows_runtime_dynamic_libraries_test.bzl", "windows_runtime_dynamic_libraries_assertion")
 
@@ -94,6 +95,20 @@ _EXTERNAL_INCLUDE_PATHS_TEST_COMPATIBLE = (
 ) if bazel_features.cc.supports_starlarkified_toolchains else ["@platforms//:incompatible"]
 
 musl_header_generation_tests(name = "musl_header_generation_tests")
+
+thin_lto_features_test(
+    name = "thin_lto_shared_backends_disabled_test",
+)
+
+thin_lto_features_test(
+    name = "thin_lto_linkstatic_tests_shared_backends_test",
+    shared_backend_features = ["thin_lto_linkstatic_tests_use_shared_nonlto_backends"],
+)
+
+thin_lto_features_test(
+    name = "thin_lto_all_linkstatic_shared_backends_test",
+    shared_backend_features = ["thin_lto_all_linkstatic_use_shared_nonlto_backends"],
+)
 
 cc_library(
     name = "objc_c_lib",

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -96,18 +96,23 @@ _EXTERNAL_INCLUDE_PATHS_TEST_COMPATIBLE = (
 
 musl_header_generation_tests(name = "musl_header_generation_tests")
 
+# Windows CI checks these features with bazel build because the Windows test
+# wrapper cannot execute the analysis test's generated shell script.
 thin_lto_features_test(
     name = "thin_lto_shared_backends_disabled_test",
+    tags = ["thin_lto_feature"],
 )
 
 thin_lto_features_test(
     name = "thin_lto_linkstatic_tests_shared_backends_test",
     shared_backend_features = ["thin_lto_linkstatic_tests_use_shared_nonlto_backends"],
+    tags = ["thin_lto_feature"],
 )
 
 thin_lto_features_test(
     name = "thin_lto_all_linkstatic_shared_backends_test",
     shared_backend_features = ["thin_lto_all_linkstatic_use_shared_nonlto_backends"],
+    tags = ["thin_lto_feature"],
 )
 
 cc_library(

--- a/e2e/rules_cc/thin_lto_features_test.bzl
+++ b/e2e/rules_cc/thin_lto_features_test.bzl
@@ -1,0 +1,44 @@
+"""Tests shared ThinLTO backend feature selection in the LLVM toolchain."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+
+_SHARED_BACKEND_FEATURES = [
+    "thin_lto_linkstatic_tests_use_shared_nonlto_backends",
+    "thin_lto_all_linkstatic_use_shared_nonlto_backends",
+]
+
+def _thin_lto_features_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = find_cpp_toolchain(ctx),
+        requested_features = ["thin_lto"] + ctx.attr.shared_backend_features,
+    )
+    asserts.true(env, cc_common.is_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = "thin_lto",
+    ))
+    for feature_name in _SHARED_BACKEND_FEATURES:
+        asserts.equals(
+            env,
+            feature_name in ctx.attr.shared_backend_features,
+            cc_common.is_enabled(
+                feature_configuration = feature_configuration,
+                feature_name = feature_name,
+            ),
+            "Unexpected state for %s" % feature_name,
+        )
+    return analysistest.end(env)
+
+thin_lto_features_test = rule(
+    implementation = _thin_lto_features_test_impl,
+    analysis_test = True,
+    attrs = {
+        "shared_backend_features": attr.string_list(),
+    },
+    fragments = ["cpp"],
+    test = True,
+    toolchains = use_cpp_toolchain(),
+)

--- a/e2e/rules_cc/thin_lto_features_test.bzl
+++ b/e2e/rules_cc/thin_lto_features_test.bzl
@@ -1,6 +1,6 @@
 """Tests shared ThinLTO backend feature selection in the LLVM toolchain."""
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
@@ -16,20 +16,20 @@ def _thin_lto_features_test_impl(ctx):
         cc_toolchain = find_cpp_toolchain(ctx),
         requested_features = ["thin_lto"] + ctx.attr.shared_backend_features,
     )
-    asserts.true(env, cc_common.is_enabled(
+    thin_lto_enabled = cc_common.is_enabled(
         feature_configuration = feature_configuration,
         feature_name = "thin_lto",
-    ))
+    )
+    if not thin_lto_enabled:
+        fail("%s: thin_lto was not enabled" % ctx.label)
     for feature_name in _SHARED_BACKEND_FEATURES:
-        asserts.equals(
-            env,
-            feature_name in ctx.attr.shared_backend_features,
-            cc_common.is_enabled(
-                feature_configuration = feature_configuration,
-                feature_name = feature_name,
-            ),
-            "Unexpected state for %s" % feature_name,
+        enabled = cc_common.is_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = feature_name,
         )
+        expected = feature_name in ctx.attr.shared_backend_features
+        if enabled != expected:
+            fail("%s: expected %s=%s, got %s" % (ctx.label, feature_name, expected, enabled))
     return analysistest.end(env)
 
 thin_lto_features_test = rule(

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -25,6 +25,8 @@ def cc_toolchain(
             "@llvm//toolchain/features:no_windows_export_all_symbols",
             "@llvm//toolchain/features:static_link_cpp_runtimes",
             "@llvm//toolchain/features:targets_windows",
+            "@llvm//toolchain/features:thin_lto_linkstatic_tests_use_shared_nonlto_backends",
+            "@llvm//toolchain/features:thin_lto_all_linkstatic_use_shared_nonlto_backends",
             "@llvm//toolchain/features:windows_export_all_symbols",
             "@llvm//toolchain/features/legacy:clang_cl_all_legacy_builtin_features",
             "@llvm//toolchain/features/legacy:clang_cl_experimental_replace_legacy_action_config_features",
@@ -102,6 +104,8 @@ def cc_toolchain(
             "@llvm//toolchain/features:generate_pdb_file",
             "@llvm//toolchain/features:fdo_optimize",
             "@rules_cc//cc/toolchains/args/thin_lto:feature",
+            "@llvm//toolchain/features:thin_lto_linkstatic_tests_use_shared_nonlto_backends",
+            "@llvm//toolchain/features:thin_lto_all_linkstatic_use_shared_nonlto_backends",
         ] + select({
             "@platforms//os:linux": [
                 "@llvm//toolchain/features/interface_libraries:feature",

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -105,6 +105,17 @@ cc_feature(
     feature_name = "prefer_pic_for_opt_binaries",
 )
 
+# Bazel uses these opt-in features to reuse library code generation across links.
+cc_feature(
+    name = "thin_lto_linkstatic_tests_use_shared_nonlto_backends",
+    feature_name = "thin_lto_linkstatic_tests_use_shared_nonlto_backends",
+)
+
+cc_feature(
+    name = "thin_lto_all_linkstatic_use_shared_nonlto_backends",
+    feature_name = "thin_lto_all_linkstatic_use_shared_nonlto_backends",
+)
+
 # Allow external repositories to get included with -isystem instead of -I in
 # order to silence warnings from external headers. The complete generic and
 # Windows toolchain compositions expand external_include_paths before their


### PR DESCRIPTION
Declare `thin_lto_linkstatic_tests_use_shared_nonlto_backends` and `thin_lto_all_linkstatic_use_shared_nonlto_backends` in the generic and MSVC toolchains' known features. Both remain disabled by default. Previously Bazel silently ignored requests for these undeclared features, preventing users from selecting shared ThinLTO backends.

Add three tests against the real LLVM toolchain that verify the defaults and independent selection of each feature. All three pass on the Linux x86_64 toolchain with Bazel 9.2.0 and remote execution. A static C++ test calling a Rust library also compiles, links, and runs successfully with these declarations, fixed rules_cc, and both `thin_lto` and `thin_lto_linkstatic_tests_use_shared_nonlto_backends` enabled.

Related to https://github.com/hermeticbuild/rules_rust/issues/49. Rust PIC libraries also need rules_cc commit 4591082affa5a63f4f06942e14ea69984bb68ed0, which creates the PIC shared-backend map.

Regression coverage: https://github.com/hermeticbuild/rules_rust/pull/52 and https://github.com/bazelbuild/rules_cc/pull/868.

-zbarskybot
