### PR TITLE
Strip LLVM bootstrap binaries

### DIFF
--- a/toolchain/bootstrap/bootstrap_binary.bzl
+++ b/toolchain/bootstrap/bootstrap_binary.bzl
@@ -138,7 +138,7 @@ def bootstrap_binaries(**kwargs):
     for tool in ["llvm"] + TOOLCHAIN_BINARIES:
         bootstrap_binary(
             name = tool,
-            actual = "@llvm-project//llvm",
+            actual = "@llvm-project//llvm:llvm.stripped",
             visibility = ["//visibility:public"],
             **kwargs
         )


### PR DESCRIPTION
Originally stripped in https://github.com/hermeticbuild/hermetic-llvm/commit/4afd19c123ad985d22a33a2ad5b2938ae145aa45, then seem to have been inadvertently changed to unstripped in https://github.com/hermeticbuild/hermetic-llvm/commit/560f944f3f6b480d31c6ede3b7c691d13bda4d34.