### PR TITLE
Keep Clang's builtin headers before the macOS SDK headers

### DIFF
--- a/toolchain/args/compiler_resource_headers.bzl
+++ b/toolchain/args/compiler_resource_headers.bzl
@@ -33,20 +33,36 @@ def declare_clang_compile_resource_headers(
         name = name,
         actions = _COMPILE_RESOURCE_HEADER_ACTIONS,
         allowlist_include_directories = allowlist_include_directories,
-        args = [
-            # The toolchain supplies the resource headers explicitly so normal
-            # and bootstrap compilers have the same ownership model. Disable
-            # Clang's implicit entry instead of emitting the same
-            # -internal-isystem twice and relying on header-search deduplication.
-            # Do not use -resource-dir here: link actions have separate
-            # resource-directory semantics, and rules_foreign_cc may combine
-            # CC, CFLAGS, and LDFLAGS into one driver invocation.
-            "-nobuiltininc",
-            "-Xclang",
-            "-internal-isystem",
-            "-Xclang",
-            "{resource_include_directory}",
-        ],
+        # The toolchain supplies the resource headers explicitly so normal and
+        # bootstrap compilers have the same ownership model. Disable Clang's
+        # implicit entry instead of emitting the same -internal-isystem twice
+        # and relying on header-search deduplication.
+        # Do not use -resource-dir here: link actions have separate
+        # resource-directory semantics, and rules_foreign_cc may combine CC,
+        # CFLAGS, and LDFLAGS into one driver invocation.
+        args = select({
+            # The driver appends -Xclang arguments after the include
+            # directories it derives from the sysroot, so the explicit entry
+            # ends up after the SDK's /usr/include. That breaks -fmodules
+            # builds: the SDK's sys/_types/_ptrdiff_t.h (and friends) then
+            # include <stddef.h> expecting Clang's builtin header, but find the
+            # SDK's own copy, which circularly includes <_types.h>. Keep the
+            # implicit entry, which the driver places before the SDK headers,
+            # and let Clang drop the later duplicate.
+            "@platforms//os:macos": [
+                "-Xclang",
+                "-internal-isystem",
+                "-Xclang",
+                "{resource_include_directory}",
+            ],
+            "//conditions:default": [
+                "-nobuiltininc",
+                "-Xclang",
+                "-internal-isystem",
+                "-Xclang",
+                "{resource_include_directory}",
+            ],
+        }),
         data = [resource_headers_data],
         format = {
             "resource_include_directory": resource_include_directory,


### PR DESCRIPTION
The toolchain disables Clang's implicit resource include directory (`-nobuiltininc`) and passes it explicitly via `-Xclang -internal-isystem`. The driver appends `-Xclang` arguments after the include directories it derives from the sysroot, so on macOS the builtin headers end up *after* the SDK's `/usr/include` rather than before it, where Clang itself puts them. The effective search order on `main` (`clang -v`):

```
 external/+osx+macos_sdk/sysroot/usr/include
 external/+llvm+llvm-project/compiler-rt/include
 external/+llvm_toolchain_minimal+llvm-toolchain-minimal-darwin-arm64/lib/clang/23/include
```

This is invisible in regular builds, but breaks `-fmodules` builds (e.g. the header modules support in #676): the SDK's `sys/_types/_ptrdiff_t.h` (and friends) check `__has_feature(modules)` and then `#include <stddef.h>` expecting Clang's builtin header. They find the SDK's own copy first, which circularly includes `<_types.h>`, and fail with:

```
external/+osx+macos_sdk/sysroot/usr/include/_types.h:46:9: error: unknown type name '__uint32_t'
external/+osx+macos_sdk/sysroot/usr/include/arm/_types.h:75:9: error: missing '#include <__cstddef/ptrdiff_t.h>'; 'ptrdiff_t' must be declared before it is used
```

Keep the implicit entry on macOS, which the driver places before the SDK headers, and let Clang drop the later explicit duplicate (both resolve to the same directory). Other platforms are unchanged. Bootstrap stages install the builtin headers at `<prefix>/lib/clang/<N>/include`, i.e. the implicit location, so they get the same order.
