### PR TITLE
Make header_parser.c compile under MSVC

### DIFF
--- a/tools/internal/header_parser.c
+++ b/tools/internal/header_parser.c
@@ -1,9 +1,14 @@
 #include <errno.h>
-#include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
 
 int main(int argc, char **argv) {
   const char *path = getenv("PARSE_HEADER");
@@ -12,13 +17,13 @@ int main(int argc, char **argv) {
     exit(2);
   }
 
-  int fd = open(path, O_WRONLY | O_CREAT, 0666);
-  if (fd < 0) {
+  FILE *touched = fopen(path, "a");
+  if (touched == NULL) {
     fprintf(stderr, "header_parser: failed to touch %s: %s\n",
             path, strerror(errno));
     exit(2);
   }
-  if (close(fd) != 0) {
+  if (fclose(touched) != 0) {
     fprintf(stderr, "header_parser: failed to close =%s: %s\n",
             path, strerror(errno));
     exit(2);
@@ -31,7 +36,17 @@ int main(int argc, char **argv) {
   }
 
   argv[0] = (char *)clang_path;
+#ifdef _WIN32
+  intptr_t status = _spawnv(_P_WAIT, clang_path, (const char *const *)argv);
+  if (status == -1) {
+    fprintf(stderr, "header_parser: failed to execute %s: %s\n",
+            clang_path, strerror(errno));
+    return 2;
+  }
+  return (int)status;
+#else
   execv(clang_path, argv);
   fprintf(stderr, "header_parser: execv failed: %s\n", strerror(errno));
   return 2;
+#endif
 }


### PR DESCRIPTION
`tools/internal/header_parser.c` includes `<unistd.h>` for `open`, `close` and `execv`, which MSVC doesn't ship. It is bound to `cpp_header_parsing` in the toolchain's tool map and built `[for tool]`, so on a Windows host with an MSVC exec platform every toolchain instantiation fails with `fatal error C1083: Cannot open include file: 'unistd.h'`, even with the `parse_headers` feature disabled.

The touch now uses `fopen`/`fclose`, which is portable and avoids `_open` rejecting the `0666` mode through the invalid parameter handler on Windows. The exec on Windows is `_spawnv(_P_WAIT, ...)` returning the child's status, matching `link_wrapper.c`, since `_execv` returns to the caller with the child still running and would lose clang's exit status. A `#define open _open` / `#define execv _execv` shim would have kept the diff include-only but carried both of those problems.