### PR TITLE
Factor runtime architecture and libc selectors

### DIFF
--- a/kernel/extension/make_select_kernel_headers_repository_target.bzl
+++ b/kernel/extension/make_select_kernel_headers_repository_target.bzl
@@ -39,18 +39,32 @@ def _make_select_kernel_headers_repository_target_for_linux_kernel(kernel_versio
 
     return select(selection)
 
-def _make_select_kernel_headers_repository_target_from_libc(bazel_target):
-    """Select the right kernel headers repository based on the target architecture and libc version."""
-    selection = {}
+def _declare_libc_kernel_headers_aliases(name, bazel_target):
+    """Select the architecture before its libc-derived kernel version."""
+    targets = {}
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
+        versions = {}
         for libc_version in LIBCS + ["unconstrained"]:
             kernel_version = LIBC_KERNEL_VERSIONS[libc_version]
             if not _kernel_headers_available(target_arch, kernel_version):
                 continue
-            apparent_target = _kernel_headers_repository_target(target_arch, kernel_version, bazel_target)
-            selection["@llvm//platforms/config:{}_{}_{}".format(target_os, target_arch, libc_version)] = apparent_target
+            versions["@llvm//constraints/libc:{}".format(libc_version)] = _kernel_headers_repository_target(target_arch, kernel_version, bazel_target)
 
-    return select(selection)
+        if not versions:
+            continue
+
+        target_name = "{}_{}_{}".format(name, target_os, target_arch)
+        native.alias(
+            name = target_name,
+            actual = select(versions),
+            visibility = ["//visibility:private"],
+        )
+        targets["@llvm//platforms/config:{}_{}".format(target_os, target_arch)] = target_name
+
+    native.alias(
+        name = name,
+        actual = select(targets),
+    )
 
 def _make_select_kernel_headers_repository_target_from_linux_kernel(bazel_target):
     """Select explicit Linux kernel constraints, falling back to the libc-derived default."""
@@ -73,10 +87,7 @@ def declare_kernel_headers_repository_target(name, bazel_target = None, **kwargs
     if bazel_target == None:
         bazel_target = name
 
-    native.alias(
-        name = _fallback_alias_name(name),
-        actual = _make_select_kernel_headers_repository_target_from_libc(bazel_target),
-    )
+    _declare_libc_kernel_headers_aliases(_fallback_alias_name(name), bazel_target)
 
     for kernel_version in LINUX_KERNEL_VERSIONS:
         native.alias(

--- a/runtimes/glibc/extension/make_select_glibc_repository_target.bzl
+++ b/runtimes/glibc/extension/make_select_glibc_repository_target.bzl
@@ -2,17 +2,30 @@ load("//constraints/libc:libc_versions.bzl", "DEFAULT_LIBC", "GLIBCS")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 load(":glibc.bzl", "glibc_triple")
 
-def make_select_glibc_repository_target(bazel_repository, bazel_target):
-    selection = {}
+def declare_glibc_repository_target(name, bazel_repository, bazel_target, **kwargs):
+    """Select a target architecture before selecting its glibc version."""
+    targets = {}
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
         triple = glibc_triple(target_os, target_arch)
+        versions = {}
         for libc_version in GLIBCS + ["unconstrained"]:
             apparent_libc_value = libc_version if libc_version != "unconstrained" else DEFAULT_LIBC
 
             # libc constraint values are "gnu.X.Y"; the glibc repos are keyed
             # by the numeric version only.
             glibc_version = apparent_libc_value.split(".", 1)[1]
-            apparent_target = "{}_{}.{}//:{}".format(bazel_repository, triple, glibc_version, bazel_target)
-            selection["@llvm//platforms/config:{}_{}_{}".format(target_os, target_arch, libc_version)] = apparent_target
+            versions["@llvm//constraints/libc:{}".format(libc_version)] = "{}_{}.{}//:{}".format(bazel_repository, triple, glibc_version, bazel_target)
 
-    return select(selection)
+        target_name = "{}_{}_{}".format(name, target_os, target_arch)
+        native.alias(
+            name = target_name,
+            actual = select(versions),
+            visibility = ["//visibility:private"],
+        )
+        targets["@llvm//platforms/config:{}_{}".format(target_os, target_arch)] = target_name
+
+    native.alias(
+        name = name,
+        actual = select(targets),
+        **kwargs
+    )

--- a/runtimes/glibc/extension/trampoline.BUILD.bazel
+++ b/runtimes/glibc/extension/trampoline.BUILD.bazel
@@ -1,33 +1,38 @@
-load("@llvm//runtimes/glibc/extension:make_select_glibc_repository_target.bzl", "make_select_glibc_repository_target")
+load("@llvm//runtimes/glibc/extension:make_select_glibc_repository_target.bzl", "declare_glibc_repository_target")
 
 package(default_visibility = ["//visibility:public"])
 
-alias(
+declare_glibc_repository_target(
     name = "gnu_libc_headers",
-    actual = make_select_glibc_repository_target("@glibc_headers", "gnu_libc_headers"),
+    bazel_repository = "@glibc_headers",
+    bazel_target = "gnu_libc_headers",
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-alias(
+declare_glibc_repository_target(
     name = "glibc_headers_directory",
-    actual = make_select_glibc_repository_target("@glibc_headers", "glibc_headers_directory"),
+    bazel_repository = "@glibc_headers",
+    bazel_target = "glibc_headers_directory",
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-alias(
+declare_glibc_repository_target(
     name = "glibc_c_nonshared.static",
-    actual = make_select_glibc_repository_target("@glibc", "c_nonshared"),
+    bazel_repository = "@glibc",
+    bazel_target = "c_nonshared",
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-alias(
+declare_glibc_repository_target(
     name = "glibc_Scrt1.object",
-    actual = make_select_glibc_repository_target("@glibc", "glibc_Scrt1.object"),
+    bazel_repository = "@glibc",
+    bazel_target = "glibc_Scrt1.object",
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-alias(
+declare_glibc_repository_target(
     name = "glibc_crt1.object",
-    actual = make_select_glibc_repository_target("@glibc", "glibc_crt1.object"),
+    bazel_repository = "@glibc",
+    bazel_target = "glibc_crt1.object",
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/runtimes/glibc/libc_aware_target_triple.bzl
+++ b/runtimes/glibc/libc_aware_target_triple.bzl
@@ -1,31 +1,29 @@
 load("//constraints/libc:libc_versions.bzl", "DEFAULT_LIBC", "LIBCS")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 
-# Per-cpu remaps for zig target triples. Zig uses generic arch names with an
-# ABI-bearing libc suffix (e.g. arm/gnueabihf), not bazel's (armv7/gnu).
+# Zig uses arm rather than Bazel's armv7.
 _ZIG_CPU_OVERRIDES = {
     "armv7": "arm",
 }
 
-_ZIG_LIBC_FAMILY_OVERRIDES = {
-    ("armv7", "gnu"): "gnueabihf",
-    ("armv7", "musl"): "musleabihf",
-}
-
-def _zig_triple(target_os, target_cpu, target_libc_suffix):
-    zig_cpu = _ZIG_CPU_OVERRIDES.get(target_cpu, target_cpu)
-    libc_family, _, libc_version = target_libc_suffix.partition(".")
-    zig_libc_family = _ZIG_LIBC_FAMILY_OVERRIDES.get((target_cpu, libc_family), libc_family)
-    zig_libc_suffix = zig_libc_family + ("." + libc_version if libc_version else "")
-    return "{}-{}-{}".format(zig_cpu, target_os, zig_libc_suffix)
-
-# For use with zig tools that consume parse zig targets triples
-# Zig target triples only, not LLVM
+# Zig target triples only, not LLVM.
 def libc_aware_target_triple():
-    target = {}
-    for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS:
-        for libc_version in LIBCS + ["unconstrained"]:
-            target_libc_suffix = libc_version if libc_version != "unconstrained" else DEFAULT_LIBC
-            target["//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc_version)] = _zig_triple(target_os, target_cpu, target_libc_suffix)
+    prefixes = {
+        "//platforms/config:{}_{}".format(target_os, target_cpu): "{}-{}-".format(_ZIG_CPU_OVERRIDES.get(target_cpu, target_cpu), target_os)
+        for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS
+    }
+    families = {}
+    versions = {}
+    for libc in LIBCS + ["unconstrained"]:
+        suffix = libc if libc != "unconstrained" else DEFAULT_LIBC
+        family, _, version = suffix.partition(".")
+        constraint = "//constraints/libc:{}".format(libc)
+        families[constraint] = family
+        versions[constraint] = "." + version if version else ""
 
-    return select(target)
+    # Keep architecture and libc predicates independent instead of matching
+    # their full cross-product. ARM's ABI suffix precedes the libc version.
+    return select(prefixes) + select(families) + select({
+        "//platforms/config:linux_armv7": "eabihf",
+        "//conditions:default": "",
+    }) + select(versions)


### PR DESCRIPTION
Select architecture before libc in runtime aliases and compose Zig target triples from independent selectors. Avoid evaluating the architecture and libc cross-product in every consuming configuration.

Preserve default libc, ARM ABI, kernel availability, and explicit kernel overrides. This reduces configured targets and retained memory in large analysis graphs without changing the selected runtime files.