### PR TITLE
Enforce graph-wide MSVC CRT selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,11 @@ bazel build \
 
 MSVC targets default to the retail dynamic CRT (`/MD`). Select the retail static
 CRT (`/MT`) with
-`--features=-dynamic_link_msvcrt,static_link_msvcrt`. Debug CRT modes (`/MDd`
-and `/MTd`) are not supported. Sanitizers, coverage/FDO, header parsing, module
+`--@llvm//toolchain/features/msvc:crt_mode=static`. Debug CRT modes (`/MDd`
+and `/MTd`) are not supported. CRT selection is configuration-wide because the
+entire C/C++ dependency closure, including libc++ and compiler-rt, must use the
+same mode. Target-local `features` requests that disagree with the configured
+mode fail during analysis. Sanitizers, coverage/FDO, header parsing, module
 maps, and layering checks are also not yet supported for MSVC targets; requests
 for unsupported features fail during analysis rather than being ignored.
 

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -1418,6 +1418,34 @@ cc_library(
 )
 
 cc_library(
+    name = "windows_msvc_target_local_static_crt_probe",
+    testonly = True,
+    srcs = ["windows_msvc_crt_default_probe.c"],
+    features = [
+        "-dynamic_link_msvcrt",
+        "static_link_msvcrt",
+    ],
+    target_compatible_with = [
+        "@llvm//constraints/windows/abi:msvc",
+        "@platforms//os:windows",
+    ],
+)
+
+cc_library(
+    name = "windows_msvc_target_local_dynamic_crt_probe",
+    testonly = True,
+    srcs = ["windows_msvc_crt_default_probe.c"],
+    features = [
+        "dynamic_link_msvcrt",
+        "-static_link_msvcrt",
+    ],
+    target_compatible_with = [
+        "@llvm//constraints/windows/abi:msvc",
+        "@platforms//os:windows",
+    ],
+)
+
+cc_library(
     name = "windows_msvc_unsupported_feature_probe",
     testonly = True,
     srcs = ["windows_msvc_crt_default_probe.c"],

--- a/e2e/rules_cc/windows_msvc_action_test.sh
+++ b/e2e/rules_cc/windows_msvc_action_test.sh
@@ -233,8 +233,7 @@ bazel --bazelrc=.bazelrc aquery "${common_flags[@]}" \
   >"${action_dir}/thin-lto-link.txt"
 bazel --bazelrc=.bazelrc aquery "${common_flags[@]}" \
   --features=thin_lto \
-  --features=-dynamic_link_msvcrt \
-  --features=static_link_msvcrt \
+  --@llvm//toolchain/features/msvc:crt_mode=static \
   --@llvm//toolchain:bootstrap_stage=stage1_from_source \
   --features=-compiler_param_file \
   --output=commands \
@@ -242,8 +241,7 @@ bazel --bazelrc=.bazelrc aquery "${common_flags[@]}" \
   >"${action_dir}/stage1-libcxx-compile.txt"
 bazel --bazelrc=.bazelrc aquery "${common_flags[@]}" \
   --features=thin_lto \
-  --features=-dynamic_link_msvcrt \
-  --features=static_link_msvcrt \
+  --@llvm//toolchain/features/msvc:crt_mode=static \
   --@llvm//toolchain:bootstrap_stage=stage1_from_source \
   --include_param_files \
   --output=text \
@@ -251,8 +249,7 @@ bazel --bazelrc=.bazelrc aquery "${common_flags[@]}" \
   >"${action_dir}/stage1-thin-lto-index.txt"
 bazel --bazelrc=.bazelrc aquery "${common_flags[@]}" \
   --features=thin_lto \
-  --features=-dynamic_link_msvcrt \
-  --features=static_link_msvcrt \
+  --@llvm//toolchain/features/msvc:crt_mode=static \
   --@llvm//toolchain:bootstrap_stage=stage1_from_source \
   --include_param_files \
   --output=text \
@@ -294,8 +291,7 @@ bazel --bazelrc=.bazelrc cquery "${common_flags[@]}" \
   'kind(".*cc_toolchain.*", deps(//:windows_msvc_crt_default_probe))' \
   >"${action_dir}/resolved-toolchains.txt"
 bazel --bazelrc=.bazelrc build "${common_flags[@]}" \
-  --features=-dynamic_link_msvcrt \
-  --features=static_link_msvcrt \
+  --@llvm//toolchain/features/msvc:crt_mode=static \
   --@llvm//toolchain:bootstrap_stage=stage1_from_source \
   //:windows_msvc_thinlto_weak_alias
 

--- a/e2e/rules_cc/windows_msvc_analysis_test.sh
+++ b/e2e/rules_cc/windows_msvc_analysis_test.sh
@@ -70,6 +70,21 @@ expect_failure \
   //:windows_msvc_crt_default_probe
 
 expect_failure \
+  windows-msvc-target-local-static-crt \
+  "is provided by all of the following features: msvc_configured_dynamic_crt static_link_msvcrt" \
+  "${common_flags[@]}" \
+  --platforms=@llvm//platforms:windows_x86_64_msvc \
+  //:windows_msvc_target_local_static_crt_probe
+
+expect_failure \
+  windows-msvc-target-local-dynamic-crt \
+  "is provided by all of the following features: dynamic_link_msvcrt msvc_configured_static_crt" \
+  "${common_flags[@]}" \
+  --@llvm//toolchain/features/msvc:crt_mode=static \
+  --platforms=@llvm//platforms:windows_x86_64_msvc \
+  //:windows_msvc_target_local_dynamic_crt_probe
+
+expect_failure \
   windows-msvc-unsupported-feature \
   "is provided by all of the following features: msvc_supported_configuration asan" \
   "${common_flags[@]}" \

--- a/e2e/rules_cc/windows_msvc_artifacts.bzl
+++ b/e2e/rules_cc/windows_msvc_artifacts.bzl
@@ -1,29 +1,16 @@
 """Configuration-wide CRT selection for MSVC artifact tests."""
 
-def _crt_transition_impl(settings, attr):
-    features = [
-        feature
-        for feature in settings["//command_line_option:features"]
-        if feature not in [
-            "-dynamic_link_msvcrt",
-            "-static_link_msvcrt",
-            "dynamic_link_msvcrt",
-            "static_link_msvcrt",
-        ]
-    ]
-    features.extend(
-        ["-dynamic_link_msvcrt", "static_link_msvcrt"] if attr.static_crt else ["-static_link_msvcrt", "dynamic_link_msvcrt"],
-    )
+def _crt_transition_impl(_settings, attr):
     return {
-        "//command_line_option:features": features,
+        "@llvm//toolchain/features/msvc:crt_mode": "static" if attr.static_crt else "dynamic",
         "//command_line_option:platforms": str(attr.target_platform),
     }
 
 _crt_transition = transition(
     implementation = _crt_transition_impl,
-    inputs = ["//command_line_option:features"],
+    inputs = [],
     outputs = [
-        "//command_line_option:features",
+        "@llvm//toolchain/features/msvc:crt_mode",
         "//command_line_option:platforms",
     ],
 )

--- a/e2e/rules_cc/windows_msvc_native_exec_validation.sh
+++ b/e2e/rules_cc/windows_msvc_native_exec_validation.sh
@@ -147,16 +147,14 @@ for target_cpu in x86_64 aarch64; do
 
   run_bazel build \
     "--platforms=${platform}" \
-    --features=-dynamic_link_msvcrt \
-    --features=static_link_msvcrt \
+    --@llvm//toolchain/features/msvc:crt_mode=static \
     //:windows_msvc_generated_def_thinlto_binary \
     //:windows_msvc_libcxx_behavior_mt
 done
 
 run_bazel test \
   "--platforms=@llvm//platforms:windows_${exec_cpu}_msvc" \
-  --features=-dynamic_link_msvcrt \
-  --features=static_link_msvcrt \
+  --@llvm//toolchain/features/msvc:crt_mode=static \
   //:windows_msvc_libcxx_behavior_mt
 
 echo "Native Windows GNU/MinGW-built clang-cl MSVC execution validation passed."

--- a/toolchain/features/msvc/BUILD.bazel
+++ b/toolchain/features/msvc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
@@ -193,11 +194,40 @@ cc_feature(
 
 config_setting(
     name = "static_crt_config",
-    values = {"features": "static_link_msvcrt"},
+    flag_values = {":crt_mode": "static"},
 )
 
 cc_mutually_exclusive_category(
+    name = "crt_feature_mode",
+)
+
+cc_mutually_exclusive_category(
+    name = "dynamic_crt_configuration",
+)
+
+cc_mutually_exclusive_category(
+    name = "static_crt_configuration",
+)
+
+cc_feature(
+    name = "configured_dynamic_crt",
+    feature_name = "msvc_configured_dynamic_crt",
+    mutually_exclusive = [":dynamic_crt_configuration"],
+)
+
+cc_feature(
+    name = "configured_static_crt",
+    feature_name = "msvc_configured_static_crt",
+    mutually_exclusive = [":static_crt_configuration"],
+)
+
+string_flag(
     name = "crt_mode",
+    build_setting_default = "dynamic",
+    values = [
+        "dynamic",
+        "static",
+    ],
 )
 
 cc_args(
@@ -209,7 +239,10 @@ cc_args(
 cc_feature(
     name = "static_link_msvcrt",
     feature_name = "static_link_msvcrt",
-    mutually_exclusive = [":crt_mode"],
+    mutually_exclusive = [
+        ":crt_feature_mode",
+        ":dynamic_crt_configuration",
+    ],
 )
 
 cc_args(
@@ -221,7 +254,24 @@ cc_args(
 cc_feature(
     name = "dynamic_link_msvcrt",
     feature_name = "dynamic_link_msvcrt",
-    mutually_exclusive = [":crt_mode"],
+    mutually_exclusive = [
+        ":crt_feature_mode",
+        ":static_crt_configuration",
+    ],
+)
+
+cc_feature_set(
+    name = "configured_crt_mode",
+    all_of = select({
+        ":static_crt_config": [
+            ":configured_static_crt",
+            ":static_link_msvcrt",
+        ],
+        "//conditions:default": [
+            ":configured_dynamic_crt",
+            ":dynamic_link_msvcrt",
+        ],
+    }),
 )
 
 cc_args_list(
@@ -261,6 +311,8 @@ cc_args(
 cc_feature_set(
     name = "abi_known_features",
     all_of = [
+        ":configured_dynamic_crt",
+        ":configured_static_crt",
         ":dynamic_link_msvcrt",
         ":dynamic_linking_mode",
         ":interface_library",
@@ -276,7 +328,7 @@ cc_feature_set(
 cc_feature_set(
     name = "abi_enabled_features",
     all_of = [
-        ":dynamic_link_msvcrt",
+        ":configured_crt_mode",
         ":interface_library",
         ":supported_configuration",
     ],


### PR DESCRIPTION
## Problem

MSVC CRT mode is a property of the complete configured dependency closure, but the current interface uses ordinary C++ features. A target-local `features` override can therefore change `/MD` to `/MT` for one target while libc++, compiler-rt, native dependencies, and runtime library selection remain in the configuration-wide mode.

This occurred downstream when Rust selected `+crt-static` independently of the C toolchain. Making both CRT library directories searchable allowed the link to proceed but did not make the closure consistent.

## Change

- Add an explicit `//toolchain/features/msvc:crt_mode` build setting with `dynamic` and `static` values.
- Select the CRT compile arguments, runtime libraries, and runtime construction topology from that setting.
- Add configured-mode marker features that conflict with an opposing target-local `dynamic_link_msvcrt` or `static_link_msvcrt` request.
- Update artifact transitions, action checks, native execution validation, and documentation to use the build setting.
- Add negative analysis coverage for both target-local mismatch directions.

The default remains dynamic `/MD`. Static `/MT` is selected with:

```sh
--@llvm//toolchain/features/msvc:crt_mode=static
```

Fixes #721.

## Validation

- Buildifier check passed.
- Default dynamic and explicit static configurations analyze successfully.
- Target-local static-under-dynamic and dynamic-under-static requests fail during feature configuration.
- The x86-64/ARM64, dynamic/static artifact matrix analyzes through its updated transition.
