### PR TITLE
Pass --sysroot=/dev/null to cc_stage0_object relocatable links

### DIFF
--- a/toolchain/runtimes/cc_stage0_object.bzl
+++ b/toolchain/runtimes/cc_stage0_object.bzl
@@ -78,6 +78,12 @@ def _cc_stage0_object_impl(ctx):
 
     arguments = ctx.actions.args()
     arguments.add("-fuse-ld=lld")
+    # A -r link resolves no libraries, so nothing from a sysroot can reach the
+    # output, but without one the clang driver still scans the host
+    # /usr/lib/gcc for GCC installations and warns
+    # (-Wgcc-install-dir-libstdcxx) on hosts with more than one. Use the same
+    # empty sysroot every toolchain-configured action already gets.
+    arguments.add("--sysroot=/dev/null")
     arguments.add_all(ctx.attr.copts)
     arguments.add("-r")
     for src in ctx.files.srcs:


### PR DESCRIPTION
## What

`cc_stage0_object` drives the raw clang driver (`clang++ -fuse-ld=lld -r ...`) via `ctx.actions.run`, so it misses the `--sysroot=/dev/null` that the `empty_sysroot_flags` cc_args inject into every toolchain-configured compile and link action. Without a sysroot, the clang driver scans the host `/usr/lib/gcc` for GCC installations on every invocation, and on hosts with more than one GCC installed (e.g. Debian/Ubuntu with gcc-13 + libstdc++-13-dev next to a bare gcc-14) each crti/crtn/Scrt1/crtbegin/crtend action prints:

```
clang++: warning: future releases of the clang compiler will prefer GCC installations containing libstdc++ include directories; '/usr/lib/gcc/x86_64-linux-gnu/13' would be chosen over '/usr/lib/gcc/x86_64-linux-gnu/14' [-Wgcc-install-dir-libstdcxx]
```

This adds `--sysroot=/dev/null` to the stage0 driver invocation, matching the rest of the toolchain, so the driver never inspects the host.

## Why unconditional (not gated on //config:empty_sysroot)

A `-r` relocatable link with no `-l` flags resolves no libraries, so nothing from a sysroot can reach the output in any configuration — the `empty_sysroot` escape hatch exists for dependencies that link host system libraries, which cannot apply here. The outputs are bit-identical before and after; only the host scan (and its warning) goes away.

Verified in a downstream repo carrying this as a module patch: all `CcStage0Compile` actions (crti/crtn, compiler-rt crtbegin/crtend, glibc Scrt1) rebuild warning-free and the toolchain works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)